### PR TITLE
Add thumbnail and screenshot gallery to video-digest

### DIFF
--- a/skills/video-digest/SKILL.md
+++ b/skills/video-digest/SKILL.md
@@ -293,12 +293,15 @@ Create `<workdir>/assets/` and populate it:
    titles, and static screens. Aim for 3-8 screenshots even for long
    videos. If no frames are notable, omit the Screenshots section.
 
+For local files (no yt-dlp download), omit the URL line and thumbnail
+if no thumbnail was downloaded.
+
 Structure the final markdown:
 
 ```markdown
 # Video Digest: <Title>
 
-**Channel:** <uploader> | **Duration:** <duration> | **Date:** <date>
+**Channel:** <uploader> | **Duration:** <duration> | **Date:** <date>\
 **URL:** <source-url>
 
 ![Video thumbnail](assets/<video_id>_thumbnail.jpg)


### PR DESCRIPTION
## Summary

- Add video thumbnail at the top of the digest markdown, right below the metadata line
- Add source URL to the header metadata (Channel, Duration, Date, URL)
- Add curated screenshot gallery at the end with aggressively filtered notable frames only
- Store all assets in `assets/` with `<video_id>_` prefix to avoid collisions across digests
- Subagents now identify notable frames (diagrams, key slides, code, demos, charts) during chunk analysis

## Test plan

- [ ] Run video-digest on a YouTube video and verify `assets/` directory is created with thumbnail and screenshots
- [ ] Verify thumbnail renders in the markdown output
- [ ] Verify screenshot gallery appears at end with captions and timestamp links
- [ ] Run on a talking-head video to confirm the gallery is omitted when no frames are notable
- [ ] Run on multiple videos sharing the same output directory to confirm no filename collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)