### PR TITLE
Promote auto memory findings to shared config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,6 +23,16 @@ docs/plans/                        Design specs and implementation plans
 - Design specs follow `docs/plans/YYYY-MM-DD-<topic>-design.md`
 - Update README.md, plugin.json, and marketplace.json when adding a new skill
 
+## Local Installation
+
+Claude Code does NOT follow symlinks in `~/.claude/commands/`. Use `scripts/sync-skills.sh` to copy skill files for local use:
+
+```bash
+./scripts/sync-skills.sh
+```
+
+This copies `skills/<name>/SKILL.md` → `~/.claude/commands/<name>.md` and helper scripts → `~/.local/bin/`. Run after editing any skill to make changes available in new Claude sessions. Auto-discovers all skills — no manual steps when adding a new skill.
+
 ## Creating New Skills
 
 Recommended workflow:

--- a/.claude/rules/shell-scripts.md
+++ b/.claude/rules/shell-scripts.md
@@ -5,6 +5,8 @@
 - `grep -P` (Perl regex) does NOT work on macOS BSD grep — use `sed` or `grep -oE`
 - `ffprobe -f lavfi "movie=<path>"` is unreliable — prefer `ffmpeg ... showinfo` + parse stderr
 - `shellcheck` passes clean but won't catch macOS-specific runtime failures — always test on macOS
+- `find` without `-L` won't follow symlinks — use `find -L` when traversing symlinked directories
+- `(( var++ ))` when var=0 exits with code 1 under `set -e` (pre-increment value is falsy) — use `(( ++var ))` instead
 
 ## YouTube VTT Parsing
 

--- a/.claude/rules/video-digest.md
+++ b/.claude/rules/video-digest.md
@@ -1,0 +1,22 @@
+# video-digest Skill
+
+## Architecture
+
+- Shell script (`video-digest.sh`) handles all external tool calls (yt-dlp, ffmpeg, whisper)
+- SKILL.md orchestrates the pipeline and subagent dispatch
+- YouTube captions first, Whisper fallback — captions are instant and free
+- Scene detection (`select=gt(scene,0.3)`) over perceptual hashing — zero extra deps
+- Contact sheets (5x4 grids) for token-efficient frame analysis
+- Short videos (< 10 min) skip chunking; long videos use parallel subagents per chapter
+
+## Known Bugs (resolved in code, documented here to prevent regressions)
+
+- YouTube auto-caption VTT has rolling 3-block cycles with zero-duration carry-over blocks — naive parsing produces 5-6x duplication. Fix: skip zero-duration blocks, extract `<c>`-tagged text, merge into ~5s groups.
+- `ffprobe -f lavfi "movie=<path>"` produces empty results for timecodes. Fix: use `ffmpeg -vf "select=...,showinfo" -f null -` and parse `pts_time:` from stderr.
+- Fixed-camera content (podcast, talking head) yields < 5 frames even at low thresholds. Fix: auto-fallback to interval sampling (1 frame/30s) when < 5 scenes on > 2 min video.
+
+## Frame Analysis Value
+
+- Talking-head videos: frames confirm visual format but add little content value
+- Tutorial/demo videos: frames surface slides, code, UI state, dashboards — details absent from audio
+- Always send contact sheets to subagents regardless — agents report what they see (or don't see)

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync skills from this repo to ~/.claude/commands/ and scripts to ~/.local/bin/
+# Run after editing skills to make changes available in new Claude sessions.
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="${REPO_DIR}/skills"
+COMMANDS_DIR="${HOME}/.claude/commands"
+BIN_DIR="${HOME}/.local/bin"
+
+mkdir -p "$COMMANDS_DIR" "$BIN_DIR"
+shopt -s nullglob
+
+synced=0
+for skill_dir in "$SKILLS_DIR"/*/; do
+  name="$(basename "$skill_dir")"
+  skill_file="${skill_dir}SKILL.md"
+
+  if [[ -f "$skill_file" ]]; then
+    cp "$skill_file" "${COMMANDS_DIR}/${name}.md"
+    (( ++synced ))
+  fi
+
+  # Sync helper scripts if present
+  for script in "${skill_dir}scripts/"*.sh; do
+    [[ -f "$script" ]] || continue
+    cp "$script" "${BIN_DIR}/$(basename "$script")"
+    chmod +x "${BIN_DIR}/$(basename "$script")"
+  done
+done
+
+echo "Synced ${synced} skills to ${COMMANDS_DIR}/"


### PR DESCRIPTION
## Summary

- Add local installation section to `CLAUDE.md` documenting `scripts/sync-skills.sh`
- Add `find -L` symlink gotcha and `(( var++ ))` set-e trap to `.claude/rules/shell-scripts.md`
- Create `.claude/rules/video-digest.md` with architecture decisions, known bugs, and frame analysis guidance
- Add `scripts/sync-skills.sh` for copying skills to `~/.claude/commands/`

## Test plan

- [ ] Run `./scripts/sync-skills.sh` and verify all 5 skills appear in a new Claude session
- [ ] Verify shell-scripts rules are picked up by Claude when editing bash scripts in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)