### PR TITLE
Add cmux-demo skill for scripted terminal demos

### DIFF
--- a/skills/cmux-demo/SKILL.md
+++ b/skills/cmux-demo/SKILL.md
@@ -1,0 +1,442 @@
+---
+name: cmux-demo
+description: >
+  ESSENTIAL for any cmux terminal demo or scripted workflow — this skill
+  contains critical cmux CLI patterns, gotchas, and conventions that
+  cannot be learned from `cmux help` alone. Without this skill, agents
+  produce demos with subtle bugs (hardcoded surface refs, broken cleanup,
+  wrong send vs send-key usage, polling instead of signal coordination).
+  Produces both a runnable bash script and a human-readable markdown
+  playbook. Covers: multi-pane IDE layouts, browser previews with CSS
+  annotations, yazi file browser integration, multi-agent workspace
+  orchestration with signal-based coordination, sidebar metadata
+  (status/progress/notifications), visual effects (trigger-flash,
+  animated resize), multi-window setups, and pane lifecycle management.
+  ALWAYS use this skill when the user mentions cmux and wants to build
+  a demo, create a terminal showcase, script a product walkthrough,
+  orchestrate a multi-pane layout, automate cmux commands into a
+  repeatable sequence, or generate any scripted cmux workflow. Trigger
+  phrases: "cmux demo", "terminal demo", "demo script", "cmux layout",
+  "cmux orchestration", "showcase", "scripted demo", "demo playbook",
+  "cmux walkthrough", "cmux presentation", "multi-agent cmux",
+  "cmux script".
+---
+
+# cmux Demo
+
+Create advanced, scripted demos that orchestrate the cmux terminal into
+a multi-pane IDE-style environment — with browser previews, file
+browsers, parallel agent workspaces, and rich sidebar feedback — all
+driven from a single bash script.
+
+The skill produces two artifacts:
+1. **A runnable `.sh` script** — self-contained, runs without LLM pauses,
+   includes cleanup
+2. **A `.md` playbook** — human-readable reference with layout diagrams,
+   command explanations, and gotchas
+
+## Utility Library
+
+A sourceable bash library is bundled at `scripts/cmux-demo-lib.sh`. It
+provides reusable functions that every demo script should use. Locate it
+the same way other skills in this repo locate their scripts:
+
+```bash
+CMUX_LIB="${CLAUDE_SKILL_DIR}/scripts/cmux-demo-lib.sh"
+```
+
+With fallback:
+```bash
+if [[ -n "${CLAUDE_SKILL_DIR:-}" ]]; then
+  CMUX_LIB="${CLAUDE_SKILL_DIR}/scripts/cmux-demo-lib.sh"
+else
+  CMUX_LIB="$(find ~/.claude -path "*/cmux-demo/scripts/cmux-demo-lib.sh" \
+    -type f 2>/dev/null | head -1)"
+fi
+```
+
+The generated demo script should **copy** the library functions it needs
+inline (not source the library at runtime) so the script is fully
+self-contained. Use the library as a reference for correct implementations.
+
+### Library Functions
+
+| Function | Purpose |
+|----------|---------|
+| **Basics** | |
+| `cmux_log`, `cmux_warn`, `cmux_err` | Colored logging |
+| `cmux_require` | Verify cmux is running |
+| `parse_field <output> <prefix>` | Extract `surface:NN` / `workspace:NN` from cmux output |
+| `detect_tools` | Check available panel-content tools (yazi, python3, node, claude) |
+| **Self-Awareness** | |
+| `cmux_identify` | Get current workspace/surface/pane context (JSON) |
+| `cmux_self <field>` | Get a specific ref (e.g., `cmux_self "workspace"` → `workspace:1`) |
+| **HTTP** | |
+| `ensure_http_server [port] [root]` | Start HTTP server if not running |
+| `kill_http_server [port]` | Kill HTTP server by port |
+| **Agent Coordination** | |
+| `wait_for_signal <name> [timeout]` | Wait for a named signal (preferred) |
+| `send_signal <name>` | Send a signal to unblock a waiter |
+| `wait_for_completions <n> [timeout]` | Poll notifications for agent completion (fallback) |
+| **Visual Effects** | |
+| `flash_surface <ref>` | Flash a surface to draw audience attention |
+| `animate_resize <pane> <dir> <total> <steps>` | Animated pane resize (grow/shrink over N steps) |
+| **Browser Annotations** | |
+| `browser_annotate <surface> <text> [position]` | Inject a CSS overlay label (top-left/right, bottom-left/right, center) |
+| `browser_highlight <surface> <selector>` | Highlight a DOM element |
+| **Pane Lifecycle** | |
+| `respawn <surface> [command]` | Restart a pane's command without rebuilding layout |
+| `breakout <surface>` | Break a pane out into its own workspace |
+| `join_into <surface> <target-pane>` | Join a surface into an existing pane |
+| **Multi-Window** | |
+| `create_window` | Create a new macOS window, return ref |
+| `move_to_window <workspace> <window>` | Move workspace to a different window |
+| **Workspaces** | |
+| `create_workspace [name]` | Create + rename workspace, return ref |
+| `demo_cleanup [port]` | Tear down all workspaces, surfaces, sidebar metadata |
+| **Timing** | |
+| `pause_short`, `pause_medium`, `pause_long` | Named timing pauses (configurable via env) |
+
+## Pipeline Overview
+
+```
+User describes their demo
+  1. Discover environment — cmux status, available tools, suggest installs
+  2. Design the demo — acts, layout, panel content, sidebar narrative
+  3. User confirms/adjusts the plan
+  4. Generate the .sh script and .md playbook
+  5. Test run the script
+  6. Iterate based on feedback
+```
+
+## Execution
+
+### Step 1: Discover Environment
+
+Before designing anything, probe what's available.
+
+First, discover the script's own context so it never accidentally
+injects into user-controlled surfaces:
+
+```bash
+cmux identify --no-caller
+# → workspace:1 surface:1 pane:1
+```
+
+Store `MY_SURFACE` so the script knows where it lives and avoids it
+when sending commands to other panes.
+
+Then check available tools:
+
+```bash
+source "$CMUX_LIB"
+detect_tools
+```
+
+This checks for: `cmux`, `yazi`, `python3`, `node`, `npx`, `claude`.
+
+**If a tool is missing, don't block — suggest alternatives:**
+
+| Missing | Impact | Alternative |
+|---------|--------|-------------|
+| `yazi` | No file browser panel | Use `ls`/`tree` in a terminal pane, or `ranger`, `lf`, `nnn` |
+| `python3` | No HTTP server for browser preview | Use `npx serve`, or `node` one-liner |
+| `node`/`npx` | No fallback HTTP server | Use `python3 -m http.server` |
+| `claude` | No multi-agent workspaces | Use any CLI command as agent stand-in, or skip the act |
+| `yazi` config | No cmux-preview integration | Preview files via `cmux browser navigate` directly |
+
+Present findings as a table and suggest `brew install <tool>` for
+anything the user might want. Proceed with whatever is available —
+the demo plan adapts to the toolset.
+
+### Step 2: Design the Demo
+
+Work with the user to design the demo structure. Gather:
+
+1. **What's being demoed?** — a product, a workflow, a tool, a concept
+2. **Who's the audience?** — developers, stakeholders, general
+3. **What panels do they want?** — IDE layout, browser preview, file
+   browser, terminals, agent workspaces
+4. **How many acts?** — typically 3-7 natural segments
+5. **Sidebar narrative?** — status updates, progress bar, notifications
+
+Don't over-interview. A brief like "demo my EDS migration workflow with
+yazi + browser preview, 4 acts" is enough to proceed.
+
+#### Layout Patterns
+
+Offer these proven layouts as starting points:
+
+**IDE Layout** (most common):
+```
++---------------------+--------------------+
+|                     |  Terminal | Browser |
+|   Main Claude Code  |  (tabbed pane)     |
+|   (surface:1)       +--------------------+
+|                     |  File Browser      |
+|                     |  (yazi / ls)       |
++---------------------+--------------------+
+```
+
+**Multi-Agent Hub**:
+```
++---------------------+
+|   Main workspace    |  <- orchestrator
++---------------------+
+| Agent 1 | Agent 2   |  <- separate workspace tabs
++---------------------+
+```
+
+**Presentation Mode**:
+```
++---------------------+--------------------+
+|                     |                    |
+|   Terminal          |   Browser Preview  |
+|   (commands)        |   (live output)    |
+|                     |                    |
++---------------------+--------------------+
+```
+
+**Full Studio** (IDE + Multi-Agent):
+```
++---------------------+--------------------+
+|                     |  Terminal | Browser |
+|   Claude Code       |  (tabbed)          |
+|   (main workspace)  +--------------------+
+|                     |  File Browser      |
++---------------------+--------------------+
++ Agent 1 workspace tab                    +
++ Agent 2 workspace tab                    +
+```
+
+**Multi-Window** (multi-monitor setups):
+```
+Window 1 (primary display)       Window 2 (secondary display)
++------------------------+       +------------------------+
+|  Main Claude Code      |       |  Browser Preview       |
+|  + terminal pane       |       |  (full-screen browser) |
++------------------------+       +------------------------+
+```
+Create with `cmux new-window`, then `cmux move-workspace-to-window`.
+
+**Dynamic Layout** (panes resize mid-demo):
+```
+Act 1: Equal split           Act 2: Browser expanded
++----------+----------+      +-----+------------------+
+| Terminal | Browser   |  →   | Trm | Browser (wider)  |
++----------+----------+      +-----+------------------+
+```
+Use `cmux resize-pane --pane <ref> -R --amount 20` to grow/shrink.
+`animate_resize` in the library does this in smooth steps.
+
+### Step 3: User Confirms
+
+Present the demo plan as a numbered act list with:
+- Act name and what happens
+- Which cmux commands are used
+- Panel content for each surface
+- Sidebar metadata updates (icon, color, label)
+- Estimated timing
+
+Let the user adjust before generating.
+
+### Step 4: Generate Artifacts
+
+Generate both artifacts into the user's chosen output directory.
+
+#### 4a. The Script (`.sh`)
+
+The script must be **fully self-contained** — inline the utility
+functions it uses from `cmux-demo-lib.sh`, don't source it at runtime.
+
+**Required structure:**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# [Demo title] — scripted cmux demo
+# Run:     bash demo.sh
+# Cleanup: bash demo.sh cleanup
+
+# ── Configuration ─────────────────────────────
+PAUSE_SHORT=1.5
+PAUSE_MEDIUM=2
+PAUSE_LONG=3
+
+# ── Utility Functions ─────────────────────────
+# (inlined from cmux-demo-lib.sh)
+log() { printf "\033[1;34m▸ %s\033[0m\n" "$1"; }
+
+parse_field() {
+  local output="$1" prefix="$2"
+  grep -o "${prefix}:[^ ]*" <<< "$output" | head -1
+}
+
+wait_for_completions() { ... }
+
+do_cleanup() { ... }
+
+if [[ "${1:-}" == "cleanup" ]]; then
+  do_cleanup
+  exit 0
+fi
+
+# Ensure cleanup runs on any error or exit
+trap do_cleanup EXIT
+
+# ── Preflight ─────────────────────────────────
+log "Preflight"
+cmux ping >/dev/null 2>&1 || { echo "Error: cmux not running" >&2; exit 1; }
+# ... start HTTP server if needed, kill stale processes
+
+# ── Act 1 — [Name] ───────────────────────────
+log "Act 1 — [Name]"
+cmux set-status "demo" "[Label]" --icon "[sf.symbol]" --color "#hex"
+# ... cmux commands with pauses
+
+# ── Act N — [Name] ───────────────────────────
+# ...
+
+# ── Finale ────────────────────────────────────
+log "Demo complete!"
+cmux set-progress 1.0 --label "Demo complete!"
+cmux notify --title "[Demo Name]" --subtitle "All acts complete" \
+  --body "[Summary of what was shown]"
+
+echo ""
+echo "Run 'bash $0 cleanup' to tear down."
+```
+
+**Script conventions:**
+- Discover own context via `cmux identify` — never assume surface:1
+- Parse dynamic refs from cmux output — never hardcode surface/workspace IDs
+- Use `parse_field` to extract `surface:NN`, `pane:NN`, `workspace:NN`
+- Track all created resources in variables for cleanup
+- Sidebar status updates at each act transition (icon + color + label)
+- `trigger-flash` on the active surface at act transitions for visual emphasis
+- Named pauses between visual transitions (the audience needs time to see)
+- `cleanup` subcommand that tears down everything created
+- Comments with act headers using `# ── Act N — Name ──` visual separators
+- Use `respawn-pane` for "reset to act N" without rebuilding layout
+- Add `trap do_cleanup EXIT` after the cleanup subcommand block so
+  interrupted runs don't leave orphaned surfaces and servers
+
+**Script gotchas to handle correctly:**
+
+| Gotcha | Correct Pattern |
+|--------|-----------------|
+| Dynamic surface refs | `out=$(cmux new-pane --direction right); SF=$(parse_field "$out" "surface")` |
+| Workspace discovery | `cmux new-workspace >/dev/null` then `cmux list-workspaces \| grep -oE 'workspace:[0-9]+' \| tail -1` |
+| Cross-workspace send | `cmux send --workspace "$WS" "command\n"` (targets active surface) |
+| Regular chars vs special keys | `cmux send` for chars (j, k, q); `cmux send-key` only for Enter, Tab |
+| Browser tab visibility | `cmux move-surface --surface "$BROWSER_SF" --focus true` after content loads |
+| Notification polling | `cmux clear-notifications` before spawning, then `wait_for_completions N` |
+| HTTP server root | Root at `/` when previewing files from arbitrary paths |
+| Interactive app quit | Send `q` via `cmux send` before `close-surface` (yazi, vim, etc.) |
+| Attention flash | `cmux trigger-flash --surface "$SF"` at act transitions |
+| Animated resize | `cmux resize-pane --pane "$PANE" -R --amount 5` in a loop for smooth grow |
+| Signal coordination | Agent runs `cmux wait-for -S "done"`, orchestrator `cmux wait-for "done"` |
+| Self-identification | `cmux identify --no-caller` to discover own surface/workspace/pane |
+| Browser annotations | `cmux browser --surface "$SF" addstyle "css"` for overlay labels |
+| DOM highlighting | `cmux browser --surface "$SF" highlight "selector"` during browser demos |
+| Pane respawn | `cmux respawn-pane --surface "$SF" --command "cmd"` to reset without rebuild |
+| Multi-window | `cmux new-window` + `move-workspace-to-window` for multi-monitor |
+| Pane reorganization | `cmux break-pane` / `join-pane` / `swap-pane` mid-demo |
+| Flash after workspace switch | `identify` returns CALLER's surface, not the switched-to workspace. Capture agent surface refs at creation time and flash those instead. |
+| Trap for cleanup | `trap do_cleanup EXIT` after the cleanup subcommand block |
+
+#### 4b. The Playbook (`.md`)
+
+The playbook is a human-readable companion to the script. Structure:
+
+```markdown
+# [Demo Title] — cmux Demo Playbook
+
+[1-2 sentence description of what the demo shows]
+
+## Prerequisites
+- cmux terminal app (verify: `cmux ping`)
+- [tool requirements with install commands]
+
+## Surface Reference Guide
+| Role | Variable | Created in |
+|------|----------|------------|
+| Main pane | `surface:1` | Pre-existing |
+| ... | ... | ... |
+
+## [Act N — Name]
+Sidebar status: `icon.name` / `#color` / "label"
+
+1. [Step with cmux command in code block]
+2. [Step with explanation of what happens]
+
+**Key gotchas:**
+- [Act-specific gotchas]
+
+---
+
+## Layout Diagram
+[ASCII art showing the final panel arrangement]
+
+## Cleanup
+[Cleanup commands]
+
+## Sidebar Commands Reference
+[Quick reference for status, progress, log, notify]
+
+## Dependencies
+[Config files, scripts, or tools needed]
+```
+
+### Step 5: Test Run
+
+After generating, run the script:
+
+```bash
+bash <script>.sh
+```
+
+Watch for errors, timing issues, or visual glitches. Common problems:
+- **Surface refs mismatch** — the script hardcoded an ID instead of parsing
+- **Too-fast transitions** — audience can't see what happened; increase pauses
+- **Browser tab hidden** — forgot `move-surface --focus true`
+- **Agent workspace not found** — workspace ref parsing failed
+
+### Step 6: Iterate
+
+Based on user feedback, adjust:
+- **Timing** — increase/decrease pauses per act
+- **Content** — change what commands run in terminal panes
+- **Layout** — add/remove/reposition panes
+- **Sidebar** — adjust icons, colors, labels
+- **Acts** — add, remove, reorder, merge
+
+Regenerate both artifacts after changes. The cleanup subcommand makes
+re-running safe — `bash demo.sh cleanup && bash demo.sh`.
+
+## Reference Material
+
+Read `references/cmux-reference.md` when generating demo scripts.
+It contains:
+
+- **cmux Command Reference** — all commands grouped by category
+  (discovery, layout, navigation, terminal I/O, synchronization,
+  browser, sidebar, workspaces, windows)
+- **SF Symbols for Sidebar** — icon names for demo status updates
+- **Yazi Integration** — config files and preview script for file
+  browser → browser preview integration
+- **Advanced Patterns** — signal-based agent coordination, visual
+  effects (flash, animated resize, swap), browser annotations (CSS
+  overlays, DOM highlighting, JS injection, state checkpoints), pane
+  reset with respawn-pane, pane reorganization (break/join), multi-
+  window demos, event hooks, data passing via buffers
+- **Important Notes** — gotchas and safety rules
+
+## Standalone Installation
+
+1. Copy `SKILL.md` to `~/.claude/commands/cmux-demo.md`
+2. Copy `scripts/cmux-demo-lib.sh` to `~/.local/bin/cmux-demo-lib.sh`
+   and `chmod +x` it
+3. The library is for reference during generation — the produced demo
+   scripts are self-contained and don't require it at runtime

--- a/skills/cmux-demo/references/cmux-reference.md
+++ b/skills/cmux-demo/references/cmux-reference.md
@@ -1,0 +1,430 @@
+# cmux Command Reference & Advanced Patterns
+
+Read this file when generating demo scripts — it contains the full
+command reference, advanced patterns, integration configs, and gotchas.
+
+## Table of Contents
+
+- [Command Reference](#cmux-command-reference)
+- [SF Symbols for Sidebar](#sf-symbols-for-sidebar)
+- [Yazi Integration](#yazi-integration)
+- [Advanced Patterns](#advanced-patterns)
+  - Signal-Based Agent Coordination
+  - Visual Effects (flash, animated resize, swap)
+  - Browser Annotations (CSS overlays, DOM highlighting, JS injection)
+  - Pane Reset with respawn-pane
+  - Pane Reorganization (break-pane, join-pane)
+  - Multi-Window Demos
+  - Event Hooks
+  - Data Passing via Buffers
+- [Important Notes](#important-notes)
+
+---
+
+## cmux Command Reference
+
+### Discovery
+```bash
+cmux ping                                  # verify cmux is running
+cmux identify [--no-caller]                # current workspace/surface/pane
+cmux capabilities                          # list supported features
+cmux find-window [--content] [--select] <query>  # search across workspaces
+```
+
+### Layout
+```bash
+cmux new-pane --direction right|left|up|down
+cmux new-split up|down|left|right --surface <ref>
+cmux new-surface --type browser --pane <ref> --url <url>
+cmux close-surface --surface <ref>
+cmux resize-pane --pane <ref> -L|-R|-U|-D [--amount N]
+cmux swap-pane --pane <ref> --target-pane <ref>
+cmux break-pane [--surface <ref>]          # pane → own workspace
+cmux join-pane --target-pane <ref> [--surface <ref>]
+cmux trigger-flash [--surface <ref>]       # visual attention flash
+```
+
+### Navigation
+```bash
+cmux select-workspace --workspace <ref>
+cmux focus-pane --pane <ref>
+cmux move-surface --surface <ref> --focus true
+cmux reorder-workspace --workspace <ref> --index <n>
+cmux reorder-surface --surface <ref> --index <n>
+```
+
+### Terminal I/O
+```bash
+cmux send --surface <ref> "text"           # regular characters
+cmux send-key --surface <ref> Enter        # special keys only
+cmux send --workspace <ref> "text"         # cross-workspace (active surface)
+cmux read-screen --surface <ref>           # read terminal output
+cmux respawn-pane --surface <ref> [--command <cmd>]  # restart pane
+cmux pipe-pane --command <shell-cmd> --surface <ref>  # stream output
+cmux set-buffer --name <name> <text>       # store data
+cmux paste-buffer --name <name> --surface <ref>       # paste into pane
+```
+
+### Synchronization
+```bash
+cmux wait-for <name> [--timeout <seconds>] # wait for a named signal
+cmux wait-for -S <name>                    # send a signal
+cmux set-hook <event> <command>            # event-driven trigger
+cmux set-hook --list                       # list registered hooks
+cmux set-hook --unset <event>              # remove a hook
+```
+
+### Browser
+```bash
+cmux browser --surface <ref> navigate <url>
+cmux browser --surface <ref> snapshot --compact
+cmux browser --surface <ref> get url|title|text|html
+cmux browser --surface <ref> click|fill|type|eval|press
+cmux browser --surface <ref> highlight <selector>
+cmux browser --surface <ref> addstyle <css>
+cmux browser --surface <ref> addscript <script>
+cmux browser --surface <ref> state save|load <path>
+cmux browser --surface <ref> tab new|list|switch|close
+cmux browser --surface <ref> wait [--load-state complete]
+# No file:// URLs — must serve via HTTP
+```
+
+### Sidebar Metadata
+```bash
+cmux set-status "key" "value" --icon "sf.symbol" --color "#hex"
+cmux clear-status "key"
+cmux set-progress 0.5 --label "text"
+cmux clear-progress
+cmux log --level info --source "name" -- "message"
+cmux clear-log
+cmux notify --title "T" --subtitle "S" --body "B"
+```
+
+### Workspaces
+```bash
+cmux new-workspace [--command <text>]
+cmux list-workspaces
+cmux rename-workspace --workspace <ref> "name"
+cmux workspace-action --workspace <ref> --action mark-unread
+cmux close-workspace --workspace <ref>
+cmux clear-notifications
+cmux list-notifications
+```
+
+### Windows (Multi-Monitor)
+```bash
+cmux new-window
+cmux list-windows
+cmux focus-window --window <ref>
+cmux close-window --window <ref>
+cmux move-workspace-to-window --workspace <ref> --window <ref>
+```
+
+---
+
+## SF Symbols for Sidebar
+
+Good demo status icons (these are macOS SF Symbol names):
+
+| Icon | Meaning |
+|------|---------|
+| `hammer.fill` | Building / setup |
+| `terminal.fill` | Terminal activity |
+| `folder.fill` | File browsing |
+| `globe` | Web / browser |
+| `person.2.fill` | Multi-agent |
+| `arrow.triangle.swap` | Switching / navigation |
+| `star.fill` | Complete / success |
+| `play.fill` | Running / active |
+| `gear` | Configuration |
+| `magnifyingglass` | Search / discovery |
+| `doc.text.fill` | Documentation |
+| `cpu` | Processing |
+
+---
+
+## Yazi Integration
+
+If yazi is available and the user wants a file browser panel, configure
+the integration:
+
+### Required config: `~/.config/yazi/yazi.toml`
+```toml
+[mgr]
+ratio = [1, 3, 0]
+
+[plugin]
+previewers = []
+preloaders = []
+
+[opener]
+preview = [
+  { run = 'cmux-preview "$1"', desc = "Preview in cmux browser", for = "unix" },
+]
+
+[open]
+prepend_rules = [
+  { mime = "text/*", use = "preview" },
+  { mime = "image/*", use = "preview" },
+  { mime = "application/json", use = "preview" },
+  { mime = "application/pdf", use = "preview" },
+]
+```
+
+Key: use `[mgr]` not `[manager]`, and `prepend_rules` not `rules` —
+wrong key names are silently ignored.
+
+### Required script: `~/.local/bin/cmux-preview`
+```bash
+#!/bin/bash
+set -euo pipefail
+FILE="$1"
+SURFACE="${CMUX_PREVIEW_SURFACE:-surface:6}"
+PORT="${CMUX_PREVIEW_PORT:-8787}"
+FILE="$(cd "$(dirname "$FILE")" && pwd)/$(basename "$FILE")"
+if ! lsof -i :"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  python3 -m http.server "$PORT" --bind 127.0.0.1 -d / &>/dev/null &
+  sleep 0.3
+fi
+URL="http://127.0.0.1:${PORT}${FILE}"
+cmux browser --surface "$SURFACE" navigate "$URL" 2>/dev/null
+```
+
+Launch yazi with the preview surface exported:
+```bash
+cmux send --surface "$YAZI_SF" \
+  "export CMUX_PREVIEW_SURFACE=$BROWSER_SF && yazi /path/to/files\n"
+```
+
+---
+
+## Advanced Patterns
+
+### Signal-Based Agent Coordination
+
+Instead of polling `list-notifications`, use `wait-for` for clean
+synchronization between the demo script and spawned agents:
+
+```bash
+# In the demo script (orchestrator):
+cmux wait-for "agent-1-done" --timeout 60
+
+# In the agent's command (runs when agent finishes):
+# Hook the agent's exit to send a signal:
+cmux send --workspace "$A1_WS" \
+  "claude -p 'Do the task' && cmux wait-for -S agent-1-done\n"
+```
+
+`wait-for` blocks until the signal is sent — no polling, no sleep
+loops, no race conditions. Use notification polling (`wait_for_completions`)
+as a fallback when the agent's exit command can't be controlled.
+
+For multi-agent coordination, chain signals:
+```bash
+# Spawn both agents with signal-on-complete
+cmux send --workspace "$A1_WS" "task1 && cmux wait-for -S a1-done\n"
+cmux send --workspace "$A2_WS" "task2 && cmux wait-for -S a2-done\n"
+
+# Wait for both (sequentially — each blocks until signal)
+cmux wait-for "a1-done" --timeout 120
+cmux wait-for "a2-done" --timeout 120
+```
+
+### Visual Effects
+
+#### Attention Flash
+Flash a surface at act transitions to direct the audience's eye:
+```bash
+cmux trigger-flash --surface "$TERM_SF"
+sleep 0.3
+```
+
+Use at the start of each act, right after `set-status`, before
+sending commands. Subtle but effective for screen recordings.
+
+**Important:** After `cmux select-workspace`, `cmux identify` still
+returns the *caller's* surface, not the switched-to workspace's
+active surface. To flash an agent's surface during a workspace tour,
+capture the agent's surface ref at creation time:
+```bash
+# At creation time:
+A1_SF=$(cmux list-pane-surfaces --workspace "$A1_WS" \
+  | grep -oE 'surface:[0-9]+' | head -1)
+
+# During the tour:
+cmux select-workspace --workspace "$A1_WS"
+cmux trigger-flash --surface "$A1_SF"  # uses captured ref
+```
+
+#### Animated Pane Resize
+Grow or shrink panes smoothly to reveal content:
+```bash
+# Grow browser pane rightward by 20 cells in 5 steps
+for i in $(seq 1 5); do
+  cmux resize-pane --pane "$BROWSER_PANE" -R --amount 4
+  sleep 0.08
+done
+```
+
+The `animate_resize` library function wraps this pattern. Common
+use: start with a small preview pane, expand it when showing results.
+
+Directions: `-L` (left), `-R` (right), `-U` (up), `-D` (down).
+
+#### Pane Swap
+Rearrange layout without rebuilding:
+```bash
+cmux swap-pane --pane "$PANE_A" --target-pane "$PANE_B"
+```
+
+### Browser Annotations
+
+Inject CSS overlays to label what the audience is seeing:
+
+```bash
+# Add a floating label
+cmux browser --surface "$BROWSER_SF" addstyle \
+  "body::after{content:'Live Preview';position:fixed;top:10px;right:10px;\
+background:rgba(0,0,0,0.8);color:#fff;padding:8px 16px;border-radius:6px;\
+font:14px/1.4 -apple-system,system-ui,sans-serif;z-index:99999;\
+pointer-events:none}"
+```
+
+The `browser_annotate` library function provides a cleaner interface:
+```bash
+browser_annotate "$BROWSER_SF" "Step 3: Preview" "top-right"
+```
+
+Positions: `top-left`, `top-right`, `bottom-left`, `bottom-right`, `center`.
+
+#### DOM Highlighting
+Call out specific UI elements:
+```bash
+cmux browser --surface "$BROWSER_SF" highlight "button.primary"
+```
+
+#### Injecting Scripts
+Run JavaScript in the browser for dynamic content:
+```bash
+cmux browser --surface "$BROWSER_SF" addscript \
+  "document.title = 'Demo: Migration Complete'"
+```
+
+#### Browser State Checkpoints
+Save and restore browser state between acts:
+```bash
+cmux browser --surface "$BROWSER_SF" state save "/tmp/demo-checkpoint-act2.json"
+# ... later, to reset:
+cmux browser --surface "$BROWSER_SF" state load "/tmp/demo-checkpoint-act2.json"
+```
+
+### Pane Reset with `respawn-pane`
+
+Reset a terminal pane to a fresh state without rebuilding the layout:
+```bash
+cmux respawn-pane --surface "$TERM_SF" --command "echo 'Ready for Act 3'"
+```
+
+This kills the existing process and starts a new shell (or command).
+Useful for "reset to act N" workflows where the layout is fine but
+the terminal content needs to restart.
+
+### Pane Reorganization Mid-Demo
+
+Break a pane out into its own workspace (spotlight a terminal):
+```bash
+cmux break-pane --surface "$TERM_SF"
+# Terminal is now in a new workspace tab — audience sees it full-screen
+```
+
+Join it back later:
+```bash
+cmux join-pane --surface "$TERM_SF" --target-pane "$MAIN_PANE"
+```
+
+### Multi-Window Demos
+
+For multi-monitor setups or when you want separate macOS windows:
+
+```bash
+# Create a second window
+WIN2=$(cmux new-window | grep -o 'window:[^ ]*' | head -1)
+
+# Move the browser workspace to the second window
+cmux move-workspace-to-window --workspace "$BROWSER_WS" --window "$WIN2"
+```
+
+Each window is a full macOS window with its own sidebar, workspaces,
+and panes. Use this for:
+- **Presentation mode** — slides on one screen, demo on another
+- **Agent monitoring** — main work on primary, agent workspaces on secondary
+- **Before/after** — original site on one screen, migrated version on another
+
+### Event Hooks
+
+React to events instead of sleeping:
+```bash
+# Run a command when a workspace is selected
+cmux set-hook pane-focus-in "cmux set-status demo 'Active' --icon terminal.fill --color '#00FF88'"
+```
+
+Available hooks follow tmux conventions. Use `cmux set-hook --list`
+to see currently registered hooks, and `cmux set-hook --unset <event>`
+to remove them.
+
+### Data Passing via Buffers
+
+Pass data between panes without temp files:
+```bash
+# Store data
+cmux set-buffer --name "result" "Migration complete: 42 pages"
+
+# Paste into a terminal pane
+cmux paste-buffer --name "result" --surface "$TERM_SF"
+```
+
+---
+
+## Important Notes
+
+- **Self-awareness first**: Use `cmux identify --no-caller` at
+  preflight to discover the script's own surface. Never inject
+  keystrokes into the surface you're running in.
+- **cmux detection**: Run `cmux ping` once at preflight. If it fails,
+  the script cannot run — exit with a clear message.
+- **No hardcoded refs**: Surface and workspace IDs are assigned
+  dynamically. Always parse them from command output.
+- **send vs send-key**: `send-key` is ONLY for special keys (Enter,
+  Tab). Regular characters (j, k, q, any text) must use `send`.
+  Arrow key names are not recognized by `send-key`.
+- **Workspace refs don't reset**: After closing workspace:2 and
+  creating a new one, it might be workspace:4. Always discover via
+  `list-workspaces`.
+- **Browser needs HTTP**: cmux browser (WKWebView) cannot load
+  `file://` URLs. Serve content via HTTP.
+- **Cross-workspace send**: `cmux send --workspace <ref>` targets the
+  active surface in that workspace. Adding `--surface` is optional for
+  explicit targeting.
+- **Prefer signals over polling**: Use `cmux wait-for` for agent
+  coordination instead of polling `list-notifications`. Signals are
+  instant and don't race.
+- **Cleanup is essential**: Every demo script must have a `cleanup`
+  subcommand AND a `trap do_cleanup EXIT` after the cleanup block.
+  The trap ensures cleanup runs even if the script errors mid-way.
+  Without it, a failed `cmux` call under `set -e` leaves orphaned
+  surfaces, HTTP servers, and sidebar metadata behind. Also
+  `set-hook --unset` any hooks you registered.
+- **Sidebar can't be toggled**: Sidebar visibility is user-controlled.
+  The script can only set/clear metadata entries, not show/hide the
+  sidebar itself.
+- **Pause for the audience**: Transitions need sleep delays so viewers
+  can see what changed. Use named pause functions for consistency.
+  Complement with `trigger-flash` for visual emphasis.
+- **Browser annotations are additive**: `addstyle`/`addscript` inject
+  into the page permanently. Use `browser navigate` to reload and
+  clear them, or design CSS with unique class names you can toggle.
+- **Respawn vs rebuild**: Use `respawn-pane` to reset a terminal
+  without tearing down the layout. Much faster than close + recreate.
+- **Multi-window cleanup**: If the demo creates extra windows, close
+  them in cleanup. `cmux close-window` closes a window and all its
+  workspaces.

--- a/skills/cmux-demo/scripts/cmux-demo-lib.sh
+++ b/skills/cmux-demo/scripts/cmux-demo-lib.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# cmux-demo-lib.sh — Sourceable utility library for cmux demo scripts
+# Source this file, don't execute it directly.
+#
+# Usage in generated demo scripts:
+#   source "$(dirname "$0")/cmux-demo-lib.sh" 2>/dev/null \
+#     || source cmux-demo-lib.sh 2>/dev/null \
+#     || { echo "Error: cmux-demo-lib.sh not found" >&2; exit 1; }
+
+set -euo pipefail
+
+# ── Logging ──────────────────────────────────────────────
+
+cmux_log() { printf "\033[1;34m▸ %s\033[0m\n" "$1"; }
+cmux_warn() { printf "\033[1;33m⚠ %s\033[0m\n" "$1"; }
+cmux_err() { printf "\033[1;31m✗ %s\033[0m\n" "$1" >&2; }
+
+# ── Preflight ────────────────────────────────────────────
+
+# Verify cmux is available and responding.
+cmux_require() {
+  if ! cmux ping >/dev/null 2>&1; then
+    cmux_err "cmux not running. This script must run inside a cmux terminal."
+    return 1
+  fi
+}
+
+# ── Output Parsing ───────────────────────────────────────
+
+# Extract a typed ref from cmux command output.
+# Usage: parse_field "OK surface:83 workspace:1" "surface"
+#   => "surface:83"
+parse_field() {
+  local output="$1" prefix="$2"
+  grep -o "${prefix}:[^ ]*" <<< "$output" | head -1
+}
+
+# ── Tool Discovery ───────────────────────────────────────
+
+# Check which panel-content tools are available.
+# Prints a JSON-like status summary to stdout.
+# Returns 0 if cmux itself is available, 1 otherwise.
+detect_tools() {
+  local tools=()
+
+  # Core (required)
+  if cmux ping >/dev/null 2>&1; then
+    tools+=("cmux:yes")
+  else
+    tools+=("cmux:no")
+    printf '%s\n' "${tools[@]}"
+    return 1
+  fi
+
+  # File browser
+  if command -v yazi >/dev/null 2>&1; then
+    tools+=("yazi:yes")
+  else
+    tools+=("yazi:no")
+  fi
+
+  # HTTP server candidates (for browser preview)
+  if command -v python3 >/dev/null 2>&1; then
+    tools+=("python3:yes")
+  else
+    tools+=("python3:no")
+  fi
+  if command -v node >/dev/null 2>&1; then
+    tools+=("node:yes")
+  else
+    tools+=("node:no")
+  fi
+  if command -v npx >/dev/null 2>&1; then
+    tools+=("npx:yes")
+  else
+    tools+=("npx:no")
+  fi
+
+  # Claude CLI (for multi-agent)
+  if command -v claude >/dev/null 2>&1; then
+    tools+=("claude:yes")
+  else
+    tools+=("claude:no")
+  fi
+
+  printf '%s\n' "${tools[@]}"
+  return 0
+}
+
+# ── HTTP Server ──────────────────────────────────────────
+
+# Start an HTTP server rooted at a given directory if not already running.
+# Usage: ensure_http_server [port] [root_dir]
+ensure_http_server() {
+  local port="${1:-8787}"
+  local root="${2:-/}"
+
+  if lsof -i :"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -m http.server "$port" --bind 127.0.0.1 -d "$root" &>/dev/null &
+  elif command -v npx >/dev/null 2>&1; then
+    npx -y serve -l "$port" -n "$root" &>/dev/null &
+  else
+    cmux_err "No HTTP server available. Install python3 or node."
+    return 1
+  fi
+  sleep 0.5
+}
+
+# Kill the HTTP server on a given port.
+kill_http_server() {
+  local port="${1:-8787}"
+  lsof -ti :"$port" | xargs kill 2>/dev/null || true
+}
+
+# ── Self-Awareness ───────────────────────────────────────
+
+# Get the current workspace/surface/pane context.
+# Usage: my_ctx=$(cmux_identify)
+# Returns JSON with workspace, surface, pane refs.
+cmux_identify() {
+  cmux identify --no-caller 2>/dev/null
+}
+
+# Get a specific field from identify output.
+# Usage: my_ws=$(cmux_self "workspace")
+cmux_self() {
+  local field="$1"
+  cmux identify --no-caller 2>/dev/null | grep -o "${field}:[^ ]*" | head -1
+}
+
+# ── Agent Coordination ───────────────────────────────────
+
+# Signal-based synchronization (preferred over polling).
+# Agent sends: cmux wait-for -S "agent-1-done"
+# Orchestrator waits: wait_for_signal "agent-1-done" 60
+wait_for_signal() {
+  local signal_name="$1"
+  local timeout="${2:-120}"
+  cmux wait-for "$signal_name" --timeout "$timeout" 2>/dev/null
+}
+
+# Send a signal that a waiting process can receive.
+# Usage: send_signal "agent-1-done"
+send_signal() {
+  local signal_name="$1"
+  cmux wait-for -S "$signal_name" 2>/dev/null
+}
+
+# Wait for N "Completed" notifications from Claude sessions.
+# Fallback for when signal-based coordination isn't possible.
+# Relies on cmux notifications created by claude hooks on session end.
+# Call `cmux clear-notifications` BEFORE spawning agents.
+# Usage: wait_for_completions <expected_count> [timeout_seconds]
+wait_for_completions() {
+  local expected="$1"
+  local timeout="${2:-120}"
+  local elapsed=0
+
+  while (( elapsed < timeout )); do
+    local count
+    set +e
+    count=$(cmux list-notifications 2>/dev/null | grep -c "Completed")
+    set -e
+    if (( count >= expected )); then
+      return 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+  done
+
+  cmux_warn "Timed out after ${timeout}s waiting for $expected agent completions (got $count)"
+  return 1
+}
+
+# ── Workspace Helpers ────────────────────────────────────
+
+# Create a new workspace and return its ref (workspace:NN).
+# cmux new-workspace returns a UUID, not a ref — this discovers the ref.
+# Usage: ws_ref=$(create_workspace "Agent 1: Poet")
+create_workspace() {
+  local name="${1:-}"
+  cmux new-workspace >/dev/null
+
+  local ws
+  ws=$(cmux list-workspaces | grep -oE 'workspace:[0-9]+' \
+    | grep -v 'workspace:1$' | tail -1)
+
+  if [[ -n "$name" && -n "$ws" ]]; then
+    cmux rename-workspace --workspace "$ws" "$name"
+  fi
+  echo "$ws"
+}
+
+# ── Visual Effects ───────────────────────────────────────
+
+# Flash a surface to draw audience attention.
+# Usage: flash_surface "$TERM_SF"
+flash_surface() {
+  local surface="$1"
+  cmux trigger-flash --surface "$surface" 2>/dev/null || true
+}
+
+# Animate a pane resize over multiple steps.
+# Usage: animate_resize "$PANE" "R" 20 5
+#   Grows pane right by 20 cells in 5 steps.
+animate_resize() {
+  local pane="$1" direction="$2" total="${3:-20}" steps="${4:-5}"
+  local per_step=$((total / steps))
+  local i=0
+  while (( i < steps )); do
+    cmux resize-pane --pane "$pane" "-${direction}" --amount "$per_step" 2>/dev/null || true
+    sleep 0.1
+    i=$((i + 1))
+  done
+}
+
+# ── Browser Annotations ─────────────────────────────────
+
+# Inject a CSS overlay label into a browser surface.
+# Usage: browser_annotate "$BROWSER_SF" "Step 3: Preview" "top-right"
+browser_annotate() {
+  local surface="$1" text="$2" position="${3:-top-right}"
+  local css_pos=""
+  case "$position" in
+    top-left)     css_pos="top:10px;left:10px" ;;
+    top-right)    css_pos="top:10px;right:10px" ;;
+    bottom-left)  css_pos="bottom:10px;left:10px" ;;
+    bottom-right) css_pos="bottom:10px;right:10px" ;;
+    center)       css_pos="top:50%;left:50%;transform:translate(-50%,-50%)" ;;
+  esac
+  local safe_text
+  safe_text=$(printf '%s' "$text" | sed "s/'/\\\\'/g")
+  cmux browser --surface "$surface" addstyle \
+    "body::after{content:'${safe_text}';position:fixed;${css_pos};background:rgba(0,0,0,0.8);color:#fff;padding:8px 16px;border-radius:6px;font:14px/1.4 -apple-system,system-ui,sans-serif;z-index:99999;pointer-events:none}" \
+    2>/dev/null || true
+}
+
+# Highlight a DOM element in a browser surface.
+# Usage: browser_highlight "$BROWSER_SF" "button.primary"
+browser_highlight() {
+  local surface="$1" selector="$2"
+  cmux browser --surface "$surface" highlight "$selector" 2>/dev/null || true
+}
+
+# ── Pane Lifecycle ───────────────────────────────────────
+
+# Restart a pane's command without rebuilding layout.
+# Usage: respawn "$TERM_SF" "echo 'Reset!'"
+respawn() {
+  local surface="$1" command="${2:-}"
+  if [[ -n "$command" ]]; then
+    cmux respawn-pane --surface "$surface" --command "$command" 2>/dev/null || true
+  else
+    cmux respawn-pane --surface "$surface" 2>/dev/null || true
+  fi
+}
+
+# Break a pane out into its own workspace.
+# Usage: breakout "$SURFACE"
+breakout() {
+  local surface="$1"
+  cmux break-pane --surface "$surface" 2>/dev/null || true
+}
+
+# Join a surface into a target pane.
+# Usage: join_into "$SURFACE" "$TARGET_PANE"
+join_into() {
+  local surface="$1" target_pane="$2"
+  cmux join-pane --surface "$surface" --target-pane "$target_pane" 2>/dev/null || true
+}
+
+# ── Multi-Window ─────────────────────────────────────────
+
+# Create a new macOS window and return its ref.
+# Usage: win_ref=$(create_window)
+create_window() {
+  local out
+  out=$(cmux new-window 2>/dev/null)
+  parse_field "$out" "window"
+}
+
+# Move a workspace to a different window (multi-monitor setups).
+# Usage: move_to_window "$WS" "$WIN"
+move_to_window() {
+  local workspace="$1" window="$2"
+  cmux move-workspace-to-window --workspace "$workspace" --window "$window" 2>/dev/null || true
+}
+
+# ── Cleanup ──────────────────────────────────────────────
+
+# Tear down all non-primary workspaces and extra surfaces.
+# Usage: demo_cleanup [http_port]
+demo_cleanup() {
+  local http_port="${1:-8787}"
+
+  # Close agent workspaces
+  local ws
+  for ws in $(cmux list-workspaces 2>/dev/null \
+    | grep -oE 'workspace:[0-9]+' | grep -v 'workspace:1$'); do
+    cmux close-workspace --workspace "$ws" 2>/dev/null || true
+  done
+
+  # Quit interactive apps and close extra surfaces
+  local sf
+  for sf in $(cmux list-panels 2>/dev/null \
+    | grep -oE 'surface:[0-9]+' | sort -t: -k2 -n | tail -n +2); do
+    cmux send --surface "$sf" "q" 2>/dev/null || true
+    sleep 0.2
+    cmux close-surface --surface "$sf" 2>/dev/null || true
+  done
+
+  # Clear sidebar metadata
+  cmux clear-status "demo" 2>/dev/null || true
+  cmux clear-progress 2>/dev/null || true
+  cmux clear-log 2>/dev/null || true
+
+  # Restore focus
+  cmux select-workspace --workspace workspace:1 2>/dev/null || true
+  cmux focus-pane --pane pane:1 2>/dev/null || true
+
+  # Kill HTTP server
+  kill_http_server "$http_port"
+}
+
+# ── Timing / Pauses ──────────────────────────────────────
+
+# Named pauses for demo pacing. Override via environment variables.
+PAUSE_SHORT="${CMUX_DEMO_PAUSE_SHORT:-1.5}"
+PAUSE_MEDIUM="${CMUX_DEMO_PAUSE_MEDIUM:-2}"
+PAUSE_LONG="${CMUX_DEMO_PAUSE_LONG:-3}"
+
+pause_short() { sleep "$PAUSE_SHORT"; }
+pause_medium() { sleep "$PAUSE_MEDIUM"; }
+pause_long() { sleep "$PAUSE_LONG"; }


### PR DESCRIPTION
## Summary

- New `cmux-demo` skill that generates advanced scripted demos for cmux terminals
- Produces both a runnable `.sh` script and a `.md` playbook from a user's demo description
- Covers multi-pane IDE layouts, browser previews, yazi file browser, multi-agent workspace orchestration, sidebar metadata, and cleanup

## Skill structure

```
skills/cmux-demo/
├── SKILL.md                      (432 lines — 6-step pipeline)
├── references/
│   └── cmux-reference.md         (427 lines — commands, patterns, gotchas)
└── scripts/
    └── cmux-demo-lib.sh          (338 lines — 25+ utility functions)
```

## Key features

- **Tool discovery** — probes for yazi, python3, node, claude CLI and suggests alternatives for missing tools
- **6 layout patterns** — IDE, Multi-Agent Hub, Presentation, Full Studio, Multi-Window, Dynamic
- **Signal-based agent coordination** — `cmux wait-for` instead of polling
- **Visual effects** — `trigger-flash`, animated `resize-pane`, `swap-pane`
- **Browser annotations** — CSS overlays via `addstyle`, DOM highlighting, JS injection
- **Pane lifecycle** — `respawn-pane` for reset, `break-pane`/`join-pane` for reorganization
- **Self-awareness** — `cmux identify --no-caller` to avoid injecting into caller's surface
- **Trap-based cleanup** — `trap do_cleanup EXIT` ensures cleanup on errors

## Evaluation

Tested with 3 prompts (EDS migration, multi-agent, simple presentation), each with-skill and without-skill baseline:

| Eval | With Skill | Without Skill |
|------|-----------|--------------|
| EDS Migration | 4/5 | 3/5 |
| Multi-Agent | 4/5 | 2.5/5 |
| Simple Presentation | 4/5 | 2/5 |

Baselines learned cmux basics from `cmux help` but missed advanced patterns (signals, flash, annotations, identify) and had bugs (hardcoded refs, broken cleanup, wrong commands).

## Test plan

- [ ] Install skill and verify `cmux-demo` appears in skill list
- [ ] Run a simple test prompt: "create a 2-act cmux demo with terminal + browser"
- [ ] Verify generated script runs in cmux (`bash demo.sh`) and cleanup works (`bash demo.sh cleanup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)