### PR TITLE
Add headless token-based mode to slack-cdp skill

### DIFF
--- a/skills/slack-cdp/SKILL.md
+++ b/skills/slack-cdp/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: slack-cdp
 description: >
-  Control Slack desktop via CDP and REST API. Navigate channels, read/send
-  messages, search conversations, check unreads, and manage status — all
-  through Slack's Electron app with zero API tokens or bot setup. Requires
-  Slack running with --remote-debugging-port. Triggers on: slack, read slack,
-  search slack, slack unreads, send slack message, slack status, navigate
-  slack, check slack, slack messages, go to channel, slack DM.
+  Control Slack via CDP or headless API tokens. Navigate channels, read/send
+  messages, search conversations, check unreads, and manage status. Two modes:
+  CDP (Slack desktop with --remote-debugging-port) for full UI control, or
+  headless (xoxp/xoxb token) for data operations without Slack running.
+  Triggers on: slack, read slack, search slack, slack unreads, send slack
+  message, slack status, navigate slack, check slack, slack messages, go to
+  channel, slack DM.
 ---
 
 # Slack CDP
 
-Control Slack desktop via Chrome DevTools Protocol + REST API.
-Two layers: CDP key events for navigation, Slack Web API (via
-renderer eval) for data operations. Zero dependencies beyond
-Node 22 and the `cdp-connect` skill.
+Control Slack via two modes:
+
+1. **Headless** — direct Slack Web API calls with an OAuth token
+   (`SLACK_USER_TOKEN` or `SLACK_BOT_TOKEN` env var). No Slack
+   desktop needed. Covers data operations: read, send, search, status.
+2. **CDP** — Chrome DevTools Protocol via Slack's Electron app.
+   Adds UI operations: navigate, where, click, screenshot.
+
+Zero dependencies beyond Node 22. CDP mode also uses `cdp-connect`.
 
 ## Prerequisites
 
@@ -131,6 +137,76 @@ node "$CDP_JS" click '[data-qa="message_input"]' --port 9222
 ```
 
 Prefer `data-qa` attributes (Slack's own QA hooks) over CSS classes.
+
+## Headless Mode (Token-Based, No Slack App Needed)
+
+If a Slack OAuth token is available via environment variable, data
+operations can run without Slack desktop or CDP. Two token types:
+
+| Token | Env var | Acts as | Best for |
+|-------|---------|---------|----------|
+| `xoxp-` (user) | `SLACK_USER_TOKEN` | The user | Full access: read, send, search, status |
+| `xoxb-` (bot) | `SLACK_BOT_TOKEN` | The bot | Channels the bot is in; sends as @bot |
+
+**Prefer the user token** — it covers every data command. The bot
+token can only read channels it's been invited to and sends as the
+bot identity.
+
+### Headless API calls
+
+```bash
+# Auth test
+curl -s -X POST https://slack.com/api/auth.test \
+  -H "Authorization: Bearer $SLACK_USER_TOKEN"
+
+# Read channel
+curl -s -X POST https://slack.com/api/conversations.history \
+  -H "Authorization: Bearer $SLACK_USER_TOKEN" \
+  -d "channel=CHANNEL_ID&limit=10"
+
+# Search (user token only)
+curl -s -X POST https://slack.com/api/search.messages \
+  -H "Authorization: Bearer $SLACK_USER_TOKEN" \
+  -d "query=your+search&count=5"
+
+# Send message
+curl -s -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_USER_TOKEN" \
+  -d "channel=CHANNEL_ID&text=Hello"
+```
+
+### Decision: headless vs CDP
+
+Use **headless** (token) when:
+- Slack desktop is not running
+- You only need data operations (read, send, search, status)
+- Running in CI or automation
+
+Use **CDP** when:
+- You need UI operations (navigate, where, click)
+- No token is configured
+- You need to interact with app surfaces (e.g., Kite Messages tab)
+
+### Obtaining tokens
+
+**User token (`xoxp-`)** — requires a Slack app with User Token Scopes:
+
+1. In the Slack app's OAuth & Permissions page, add User Token Scopes:
+   `channels:history`, `channels:read`, `chat:write`, `search:read`,
+   `users.profile:read`, `users.profile:write`
+2. Add `https://localhost` as a Redirect URL
+3. Authorize via:
+   `https://slack.com/oauth/v2/authorize?client_id=CLIENT_ID&user_scope=channels:history,channels:read,chat:write,search:read,users.profile:read,users.profile:write&redirect_uri=https://localhost`
+4. Grab the `code` parameter from the redirect URL
+5. Exchange for token:
+   ```bash
+   curl -s -X POST https://slack.com/api/oauth.v2.access \
+     -d "client_id=CLIENT_ID&client_secret=CLIENT_SECRET&code=CODE&redirect_uri=https://localhost"
+   ```
+6. The `authed_user.access_token` field is your `xoxp-` token
+
+**Bot token (`xoxb-`)** — generated automatically when the app is
+installed to a workspace. Found on the OAuth & Permissions page.
 
 ## Error Recovery
 


### PR DESCRIPTION
## Summary

- Document dual-mode operation for slack-cdp: headless (OAuth tokens) and CDP
- Add token type comparison (`xoxp-` user vs `xoxb-` bot), API examples, decision guide
- Include step-by-step OAuth setup for obtaining user and bot tokens
- Update skill description and intro to reflect both modes

## Test plan

- [ ] Verify SKILL.md renders correctly on GitHub
- [ ] Confirm headless API examples work with a valid `xoxp-` token
- [ ] Confirm CDP mode documentation is unchanged and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)