### PR TITLE
Fix orphaned reference warnings in tessl lint

### DIFF
--- a/skills/browser-universal/SKILL.md
+++ b/skills/browser-universal/SKILL.md
@@ -76,7 +76,7 @@ Do not proceed with browser actions — this is a blocking error.
 
 ## Load Reference
 
-Load the detected layer's command reference from `references/LAYERS.md`.
+Load the detected layer's command reference from [the layers guide](references/LAYERS.md).
 Read only the section matching the detected layer (Playwright MCP, Slicc
 playwright-cli, cmux-browser, or CDP) for targeting model, key commands,
 and layer-specific gotchas.

--- a/skills/cmux-demo/SKILL.md
+++ b/skills/cmux-demo/SKILL.md
@@ -376,7 +376,7 @@ re-running safe — `bash demo.sh cleanup && bash demo.sh`.
 
 ## Reference Material
 
-Read `references/cmux-reference.md` when generating demo scripts.
+Read [the cmux reference](references/cmux-reference.md) when generating demo scripts.
 It contains:
 
 - **cmux Command Reference** — all commands grouped by category

--- a/skills/memory-triage/SKILL.md
+++ b/skills/memory-triage/SKILL.md
@@ -31,7 +31,7 @@ Parse each file into distinct entries using markdown headers (`#`, `##`,
 Classify each entry as either a **promote candidate** or **ephemeral**.
 The core question: would a different developer benefit from knowing this?
 
-See `references/CLASSIFICATION.md` for detailed examples of each category.
+See [classification examples](references/CLASSIFICATION.md) for detailed examples of each category.
 
 When uncertain, classify as promote candidate. A false positive costs the
 user one "discard" decision. A false negative buries useful knowledge.
@@ -45,7 +45,7 @@ common secret patterns (e.g., `sk-...`, `ghp_...`, `Bearer ...`,
 secrets in conversation history.
 
 Present candidates grouped by theme with rationale. See
-`references/OUTPUT-FORMATS.md` for format.
+[output formats](references/OUTPUT-FORMATS.md) for format.
 
 If there are no promote candidates:
 > "All N entries look task-specific. Nothing to promote. Say 'show filtered'
@@ -80,7 +80,7 @@ For each promoted entry:
 4. Do NOT modify or delete the source memory files.
 
 Report a summary of promoted, discarded, and unchanged entries. See
-`references/OUTPUT-FORMATS.md` for format.
+[output formats](references/OUTPUT-FORMATS.md) for format.
 
 ## Important Notes
 

--- a/skills/page-prep/SKILL.md
+++ b/skills/page-prep/SKILL.md
@@ -220,7 +220,7 @@ When `dismiss` is null, attempt in order:
    `button:has(svg)`, `button[class*="close"]`.
 3. **Element removal** — evaluate `document.querySelector('<selector>')?.remove()`.
 
-Consult `references/known-patterns.md` for CMP-specific dismiss patterns when
+Consult [known patterns](references/known-patterns.md) for CMP-specific dismiss patterns when
 the above three steps fail.
 
 ## Watch Mode

--- a/skills/video-digest/SKILL.md
+++ b/skills/video-digest/SKILL.md
@@ -180,7 +180,7 @@ determine which sheet(s) cover each chunk. A chunk may span two
 sheets — include both.
 
 Spawn one Agent per chunk using the template in
-`references/SUBAGENT-PROMPT.md`. Fill in the placeholders with each
+[the subagent prompt](references/SUBAGENT-PROMPT.md). Fill in the placeholders with each
 chunk's title, time range, transcript segment, and contact sheet
 path(s).
 


### PR DESCRIPTION
## Summary

- Use markdown link syntax `[text](references/FILE.md)` instead of backtick code spans for reference file paths in 5 skills
- Tessl only recognizes markdown links as entrypoint references per the Agent Skills spec — backtick code spans are treated as plain text

Affected: memory-triage, browser-universal, page-prep, video-digest, cmux-demo.

## Test plan

- [x] `tessl skill lint` passes clean (zero warnings) for all 5 skills
- [x] Republished all 5 to registry at 0.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)