### PR TITLE
fix(migrate-header): nav-structure format bug and worktree port detection

### DIFF
--- a/skills/migrate-header/scripts/setup-polish-loop.js
+++ b/skills/migrate-header/scripts/setup-polish-loop.js
@@ -53,7 +53,7 @@ function parseArgs(argv) {
     brandingPath: resolve(named['branding']),
     sourceDir: resolve(named['source-dir']),
     targetDir: resolve(named['target-dir']),
-    port: named['port'] || '3000',
+    explicitPort: named['port'] || null,
     maxIterations: named['max-iterations'] || '30',
   };
 }
@@ -108,10 +108,20 @@ function countNavItems(layout) {
 function buildNavStructure(layout) {
   const primary = layout.navItems?.primary || [];
   const secondary = layout.navItems?.secondary || [];
-  const topNav = [...primary, ...secondary].map((text) => ({
-    text,
-    href: '#',
+  const topNav = [...primary, ...secondary].map((item) => ({
+    text: typeof item === 'string' ? item : item.text,
+    href: typeof item === 'string' ? '#' : (item.href || '#'),
   }));
+
+  for (const entry of topNav) {
+    if (typeof entry.text !== 'string') {
+      throw new Error(
+        `nav-structure: expected .text to be a string, got ${typeof entry.text}`
+        + ` — check layout.json navItems format`
+      );
+    }
+  }
+
   return { topNav };
 }
 
@@ -122,6 +132,31 @@ function copySourceFile(sourceDir, targetDir, filename) {
     return;
   }
   copyFileSync(src, join(targetDir, filename));
+}
+
+function isLinkedWorktree(dir) {
+  try {
+    const gitDir = execSync('git rev-parse --git-dir', {
+      cwd: dir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    // Linked worktrees have .git files pointing to main repo's
+    // .git/worktrees/<name>, so --git-dir returns an absolute path
+    // containing "/worktrees/". The main working tree returns ".git".
+    return gitDir !== '.git' && gitDir.includes('/worktrees/');
+  } catch {
+    return false;
+  }
+}
+
+function detectPort(targetDir, explicitPort) {
+  if (explicitPort) return explicitPort;
+  if (isLinkedWorktree(targetDir)) {
+    log('  Detected git worktree — using port 3050 (AEM CLI worktree default)');
+    return '3050';
+  }
+  return '3000';
 }
 
 function log(msg) {
@@ -148,9 +183,10 @@ function main() {
   const headerDescription = buildHeaderDescription(layout, branding);
   const navItemCount = countNavItems(layout);
   const headerHeight = Math.round(layout.headerHeight || 0);
+  const port = detectPort(args.targetDir, args.explicitPort);
 
   const replacements = {
-    '{{PORT}}': args.port,
+    '{{PORT}}': port,
     '{{PAGE_PATH}}': '/',
     '{{MAX_ITERATIONS}}': args.maxIterations,
     '{{MAX_CONSECUTIVE_REVERTS}}': '5',


### PR DESCRIPTION
## Summary
- **Nav structure format:** `buildNavStructure` now handles both string and object nav items from `layout.json`, with a validation assertion that throws immediately on unexpected types. Previously, object-typed items were silently wrapped as nested objects, causing the evaluator to crash and score 0 on every iteration.
- **Worktree port detection:** `detectPort` checks `git rev-parse --git-dir` to identify linked worktrees and defaults to port 3050 (AEM CLI worktree default) instead of 3000. Explicit `--port=` still overrides.

Both bugs were discovered during an AstraZeneca header migration that scored 0 for 5 consecutive iterations before manual debugging.

## Test plan
- [ ] Run `setup-polish-loop.js` with layout.json containing object-typed navItems (e.g. `{ text: "R&D", href: "/r-d.html" }`) — should produce flat `nav-structure.json`
- [ ] Run `setup-polish-loop.js` with layout.json containing string navItems — should still work
- [ ] Run `setup-polish-loop.js` targeting a git worktree without `--port` — should auto-detect port 3050
- [ ] Run `setup-polish-loop.js` targeting a main working tree without `--port` — should default to 3000
- [ ] Run `setup-polish-loop.js` with explicit `--port=4000` in a worktree — should use 4000

🤖 Generated with [Claude Code](https://claude.com/claude-code)