### PR TITLE
fix(migrate-header): increase judge diagnosis cap to 3-5 + prevent loop timeout

### DIFF
--- a/skills/migrate-header/SKILL.md
+++ b/skills/migrate-header/SKILL.md
@@ -761,6 +761,10 @@ The loop runs autonomously. It terminates on:
 Do NOT attempt to control individual iterations. The loop handles
 scoring, commit/revert decisions, and termination.
 
+Do NOT wrap the loop with `timeout` or any time limit. Each iteration
+takes 8-12 minutes, so 10 iterations needs ~90+ minutes. This is
+expected — let it run to completion.
+
 Mark Phase 5 as completed. Then proceed to Phase 6 — do NOT stop here.
 
 ### Phase 6: Wrap-up

--- a/skills/migrate-header/templates/judge-first.md.tmpl
+++ b/skills/migrate-header/templates/judge-first.md.tmpl
@@ -76,4 +76,4 @@ Rules for the JSON:
 - "structure_issues": Gate 1 failures (empty if layout_ok is true)
 - "precision_issues": Gate 2 failures with actual vs expected values (empty if not evaluated or precision_ok is true)
 - "confidence": "high", "medium", or "low"
-- "diagnosis": 1-2 specific actionable items from the ACTIVE gate only. Be precise — for Gate 2, include exact CSS values to target.
+- "diagnosis": 3-5 specific actionable items from the ACTIVE gate only. Be precise — for Gate 2, include exact CSS values to target.

--- a/skills/migrate-header/templates/judge.md.tmpl
+++ b/skills/migrate-header/templates/judge.md.tmpl
@@ -82,4 +82,4 @@ Rules for the JSON:
 - "structure_issues": Gate 1 failures (empty if layout_ok is true)
 - "precision_issues": Gate 2 failures with actual vs expected values (empty if not evaluated or precision_ok is true)
 - "confidence": "high", "medium", or "low"
-- "diagnosis": 1-2 specific actionable items from the ACTIVE gate only. Be precise — for Gate 2, include exact CSS values to target.
+- "diagnosis": 3-5 specific actionable items from the ACTIVE gate only. Be precise — for Gate 2, include exact CSS values to target.


### PR DESCRIPTION
## Summary

- Increase judge diagnosis items from 1-2 to 3-5 per evaluation — the 3-gate approach constrains scope per gate, so more items within a gate should be safe
- Add explicit no-timeout instruction to prevent agents from wrapping loop.sh with `timeout 1800` (observed in AstraZeneca test run)

## Test plan

- [ ] Run migration with 3-5 diagnosis items and verify agent handles multiple items without breaking header
- [ ] Verify loop runs to completion without premature termination

🤖 Generated with [Claude Code](https://claude.com/claude-code)