### PR TITLE
feat(migrate-header): per-row parallel polish loops + bug fixes

### DIFF
--- a/.claude/rules/playwright-cli.md
+++ b/.claude/rules/playwright-cli.md
@@ -43,9 +43,24 @@ playwright-cli -s=session --raw run-code "async page => {
 }" > /tmp/output.json
 ```
 
+**Prefer `--filename=` over inline strings** for complex code — avoids shell quoting issues:
+
+```bash
+# Write code to a temp file, then run it
+cat > /tmp/extract.js << 'SCRIPT'
+async page => {
+  return await page.evaluate(() => {
+    return JSON.stringify(someComplexExtraction());
+  });
+}
+SCRIPT
+playwright-cli -s=session --raw run-code --filename=/tmp/extract.js > /tmp/output.json
+```
+
 **When to use `run-code` vs `eval`:**
 - `eval` — quick expressions: `document.title`, `el.getBoundingClientRect()`
 - `run-code` — multi-statement extraction, large DOM reads, anything > 1 line
+- `run-code --filename=` — complex code with special characters, or scripts > 3 lines
 
 ## eval only accepts pure expressions
 

--- a/.claude/rules/playwright-cli.md
+++ b/.claude/rules/playwright-cli.md
@@ -1,5 +1,19 @@
 # playwright-cli Rules
 
+## screenshot takes selector as positional argument
+
+`playwright-cli screenshot` takes the element selector as a **positional argument**, not a `--selector` flag:
+
+```bash
+# Element screenshot — selector is positional
+playwright-cli screenshot "header .header > :nth-child(1)" --filename=/tmp/row.png
+
+# Full-page screenshot — no selector
+playwright-cli screenshot --filename=/tmp/full.png
+```
+
+Do NOT use `--selector=` — it is not a valid flag.
+
 ## eval only accepts pure expressions
 
 `playwright-cli eval "EXPR"` wraps the argument as `page.evaluate(() => (EXPR))`. This means:

--- a/.claude/rules/playwright-cli.md
+++ b/.claude/rules/playwright-cli.md
@@ -46,16 +46,19 @@ playwright-cli -s=session --raw run-code "async page => {
 **Prefer `--filename=` over inline strings** for complex code — avoids shell quoting issues:
 
 ```bash
-# Write code to a temp file, then run it
-cat > /tmp/extract.js << 'SCRIPT'
+# Write code to .playwright-cli/ (inside sandbox allowed roots)
+mkdir -p .playwright-cli
+cat > .playwright-cli/extract.js << 'SCRIPT'
 async page => {
   return await page.evaluate(() => {
     return JSON.stringify(someComplexExtraction());
   });
 }
 SCRIPT
-playwright-cli -s=session --raw run-code --filename=/tmp/extract.js > /tmp/output.json
+playwright-cli -s=session --raw run-code --filename=.playwright-cli/extract.js
 ```
+
+**IMPORTANT: `--filename=` is sandboxed.** Files must be inside the project root or `.playwright-cli/`. `/tmp/` is blocked. Write temp scripts to `.playwright-cli/` and clean up after.
 
 **When to use `run-code` vs `eval`:**
 - `eval` — quick expressions: `document.title`, `el.getBoundingClientRect()`

--- a/.claude/rules/playwright-cli.md
+++ b/.claude/rules/playwright-cli.md
@@ -4,19 +4,29 @@
 
 When using any playwright-cli command — especially unfamiliar flags, subcommands, or argument syntax — look up the current docs via Context7 before writing code. Library ID: `/microsoft/playwright-cli`. Do not guess from codebase patterns or memory; the CLI evolves and has non-obvious conventions (e.g., `screenshot` takes a ref not a CSS selector, `eval` is expression-only, `--raw` strips envelope formatting).
 
-## screenshot takes selector as positional argument
+## screenshot only accepts snapshot refs, not CSS selectors
 
-`playwright-cli screenshot` takes the element selector as a **positional argument**, not a `--selector` flag:
+`playwright-cli screenshot [ref]` takes a **snapshot ref** (e.g., `e5` from a prior `snapshot` command), NOT a CSS selector:
 
 ```bash
-# Element screenshot — selector is positional
-playwright-cli screenshot "header .header > :nth-child(1)" --filename=/tmp/row.png
+# Full-page screenshot
+playwright-cli screenshot --filename=page.png
 
-# Full-page screenshot — no selector
-playwright-cli screenshot --filename=/tmp/full.png
+# Element screenshot by snapshot ref
+playwright-cli snapshot          # get refs first
+playwright-cli screenshot e5 --filename=element.png
 ```
 
-Do NOT use `--selector=` — it is not a valid flag.
+**For element screenshots by CSS selector**, use `run-code` with Playwright's `locator.screenshot()`:
+
+```bash
+playwright-cli --raw run-code "async page => {
+  await page.locator('header .header > :nth-child(1)').screenshot({ path: '/tmp/row.png' });
+  return 'ok';
+}"
+```
+
+Do NOT pass CSS selectors to `screenshot` — it only accepts refs.
 
 ## run-code for multi-statement logic
 

--- a/.claude/rules/playwright-cli.md
+++ b/.claude/rules/playwright-cli.md
@@ -1,5 +1,9 @@
 # playwright-cli Rules
 
+## Always verify with Context7
+
+When using any playwright-cli command — especially unfamiliar flags, subcommands, or argument syntax — look up the current docs via Context7 before writing code. Library ID: `/microsoft/playwright-cli`. Do not guess from codebase patterns or memory; the CLI evolves and has non-obvious conventions (e.g., `screenshot` takes a ref not a CSS selector, `eval` is expression-only, `--raw` strips envelope formatting).
+
 ## screenshot takes selector as positional argument
 
 `playwright-cli screenshot` takes the element selector as a **positional argument**, not a `--selector` flag:

--- a/.claude/rules/playwright-cli.md
+++ b/.claude/rules/playwright-cli.md
@@ -14,6 +14,25 @@ playwright-cli screenshot --filename=/tmp/full.png
 
 Do NOT use `--selector=` — it is not a valid flag.
 
+## run-code for multi-statement logic
+
+`playwright-cli run-code "async page => { ... }"` executes a full async function with `page` access. Unlike `eval` (expression-only), `run-code` supports statements, variables, `await`, and complex logic.
+
+Use `--raw` to get clean output without the `### Result` / `### Ran Playwright code` envelope:
+
+```bash
+# Extract structured data without truncation
+playwright-cli -s=session --raw run-code "async page => {
+  return await page.evaluate(() => {
+    return JSON.stringify(someComplexExtraction());
+  });
+}" > /tmp/output.json
+```
+
+**When to use `run-code` vs `eval`:**
+- `eval` — quick expressions: `document.title`, `el.getBoundingClientRect()`
+- `run-code` — multi-statement extraction, large DOM reads, anything > 1 line
+
 ## eval only accepts pure expressions
 
 `playwright-cli eval "EXPR"` wraps the argument as `page.evaluate(() => (EXPR))`. This means:

--- a/docs/superpowers/plans/2026-04-09-per-row-polish-loops.md
+++ b/docs/superpowers/plans/2026-04-09-per-row-polish-loops.md
@@ -1,0 +1,1463 @@
+# Per-Row Visual Polish Loops Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Spawn one visual polish loop per header row in parallel, then run adaptive reconciliation on the full header.
+
+**Architecture:** `setup-polish-loop.js` gains `--row=N` and `--init-css` flags to generate per-row infrastructure (loop script, evaluator, program prompt). Three new templates mirror the existing full-header templates but scoped to a single row. SKILL.md Phase 5 becomes three sub-phases: setup, parallel row dispatch, adaptive reconciliation.
+
+**Tech Stack:** Node.js (ESM), Bash, Vitest, pixelmatch/pngjs, playwright-cli
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `skills/migrate-header/scripts/setup-polish-loop.js` | Modify | Add `--row=N`, `--init-css` flags; per-row file generation; source screenshot cropping |
+| `skills/migrate-header/templates/evaluate-row.js.tmpl` | Create | Per-row evaluator: element screenshot, pixelmatch, no nav completeness |
+| `skills/migrate-header/templates/loop-row.sh.tmpl` | Create | Per-row outer loop: file-scoped git ratchet, row-prefixed sessions |
+| `skills/migrate-header/templates/program-row.md.tmpl` | Create | Per-row polish agent prompt: scoped to `row-N.css` |
+| `skills/migrate-header/SKILL.md` | Modify (lines 823–901) | Phase 5 rewrite: 5.1 setup, 5.2 parallel dispatch, 5.3 reconciliation |
+| `tests/migrate-header/setup-polish-loop.test.js` | Modify | Add tests for `--row`, `--init-css`, `cropSourceRow`, `generateInitCss` |
+
+Existing templates (`evaluate.js.tmpl`, `loop.sh.tmpl`, `program.md.tmpl`, `judge.md.tmpl`, `judge-first.md.tmpl`) are **unchanged** — they serve the reconciliation pass.
+
+---
+
+### Task 1: `evaluate-row.js.tmpl` — Per-Row Evaluator Template
+
+**Files:**
+- Create: `skills/migrate-header/templates/evaluate-row.js.tmpl`
+
+This is the per-row evaluator. It screenshots a single row element, compares against the cropped source, and outputs pixelmatch similarity. No nav completeness. Results go to `row-N/` subdirectory.
+
+- [ ] **Step 1: Create `evaluate-row.js.tmpl`**
+
+Based on `evaluate.js.tmpl` with these changes:
+- Replace `SESSION = 'header-eval'` with `SESSION = '{{ROW_SESSION}}'`
+- Replace the full-viewport screenshot + header crop logic with a single element screenshot using `{{ROW_SELECTOR}}`
+- Remove `checkNavCompleteness()` and `normalizeNavText()` entirely
+- Remove `cropHeaderFromScreenshot()` — not needed for element screenshots
+- Change `SOURCE_DIR` source image from `desktop.png` to `desktop-row-{{ROW_INDEX}}.png`
+- Change `RESULTS_DIR` to `join(__dirname, 'results', 'row-{{ROW_INDEX}}')`
+- Output only `similarity` in the composite — no `navCompleteness` field
+- Add screenshot retry: if rendered image is missing or 0 bytes after first attempt, sleep 2s and retry once
+
+```javascript
+/** IMMUTABLE EVALUATOR — the agent must not modify this file.
+ *
+ * Captures a single header row element, compares against cropped source,
+ * and outputs a pixelmatch score. Used by loop-row-N.sh for keep/discard.
+ *
+ * Usage: node autoresearch/evaluate-row-{{ROW_INDEX}}.js <port> <iteration>
+ * Output: JSON to stdout with score and breakdown
+ */
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+import { parseEvalOutput } from '{{SKILL_HOME}}/scripts/cdp-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOURCE_DIR = join(__dirname, 'source');
+const RESULTS_DIR = join(__dirname, 'results', 'row-{{ROW_INDEX}}');
+const PORT = process.argv[2] || '{{PORT}}';
+const PAGE_PATH = '{{PAGE_PATH}}';
+const ITERATION = process.argv[3] || 'latest';
+const BASE_URL = `http://localhost:${PORT}${PAGE_PATH}`;
+const SESSION = '{{ROW_SESSION}}';
+const ROW_SELECTOR = '{{ROW_SELECTOR}}';
+
+mkdirSync(RESULTS_DIR, { recursive: true });
+
+const EXEC_OPTS = { encoding: 'utf-8', timeout: 30000 };
+
+function cli(...args) {
+  return execFileSync(
+    'playwright-cli', [`-s=${SESSION}`, ...args], EXEC_OPTS,
+  ).trim();
+}
+
+function cliEval(js) {
+  return parseEvalOutput(cli('eval', js));
+}
+
+function compareImages(sourcePath, renderedPath, diffPath) {
+  if (!existsSync(sourcePath)) return { similarity: 0, error: 'source missing' };
+  if (!existsSync(renderedPath)) return { similarity: 0, error: 'rendered missing' };
+
+  const sourceImg = PNG.sync.read(readFileSync(sourcePath));
+  const renderedImg = PNG.sync.read(readFileSync(renderedPath));
+
+  const width = Math.max(sourceImg.width, renderedImg.width);
+  const height = Math.max(sourceImg.height, renderedImg.height);
+
+  const padPng = (img, w, h) => {
+    const padded = new PNG({ width: w, height: h });
+    for (let i = 0; i < padded.data.length; i += 4) {
+      padded.data[i] = 255;
+      padded.data[i + 1] = 255;
+      padded.data[i + 2] = 255;
+      padded.data[i + 3] = 255;
+    }
+    for (let y = 0; y < img.height && y < h; y++) {
+      for (let x = 0; x < img.width && x < w; x++) {
+        const srcIdx = (y * img.width + x) * 4;
+        const dstIdx = (y * w + x) * 4;
+        padded.data[dstIdx] = img.data[srcIdx];
+        padded.data[dstIdx + 1] = img.data[srcIdx + 1];
+        padded.data[dstIdx + 2] = img.data[srcIdx + 2];
+        padded.data[dstIdx + 3] = img.data[srcIdx + 3];
+      }
+    }
+    return padded;
+  };
+
+  const src = sourceImg.width === width && sourceImg.height === height
+    ? sourceImg : padPng(sourceImg, width, height);
+  const ren = renderedImg.width === width && renderedImg.height === height
+    ? renderedImg : padPng(renderedImg, width, height);
+
+  const diff = new PNG({ width, height });
+  const mismatchedPixels = pixelmatch(
+    src.data,
+    ren.data,
+    diff.data,
+    width,
+    height,
+    { threshold: 0.15, alpha: 0.5 },
+  );
+
+  writeFileSync(diffPath, PNG.sync.write(diff));
+
+  const totalPixels = width * height;
+  const similarity = ((totalPixels - mismatchedPixels) / totalPixels) * 100;
+  return {
+    similarity: Math.round(similarity * 100) / 100,
+    mismatchedPixels,
+    totalPixels,
+    width,
+    height,
+    sourceHeight: sourceImg.height,
+    renderedHeight: renderedImg.height,
+  };
+}
+
+function takeElementScreenshot(outputPath) {
+  try {
+    cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${outputPath}`);
+    if (existsSync(outputPath) && readFileSync(outputPath).length > 0) {
+      return true;
+    }
+  } catch {
+    // Fall through to retry
+  }
+  // Retry once after settling
+  execFileSync('sleep', ['2']);
+  try {
+    cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${outputPath}`);
+    return existsSync(outputPath) && readFileSync(outputPath).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Main evaluation
+const results = { viewports: {}, compositeScore: 0 };
+
+try {
+  cli('open', BASE_URL);
+} catch (err) {
+  console.error(JSON.stringify({ error: `Failed to open ${BASE_URL}: ${err.message}` }));
+  process.exit(1);
+}
+
+const sourcePath = join(SOURCE_DIR, `desktop-row-{{ROW_INDEX}}.png`);
+const renderedPath = join(RESULTS_DIR, 'desktop-rendered.png');
+const diffPath = join(RESULTS_DIR, 'desktop-diff.png');
+
+try {
+  cli('resize', '1440', '900');
+  execFileSync('sleep', ['2']);
+
+  const captured = takeElementScreenshot(renderedPath);
+
+  if (captured) {
+    const iterPath = join(RESULTS_DIR, `desktop-rendered-${ITERATION}.png`);
+    writeFileSync(iterPath, readFileSync(renderedPath));
+
+    const comparison = compareImages(sourcePath, renderedPath, diffPath);
+    results.viewports.desktop = { ...comparison, weight: 1.0 };
+  } else {
+    results.viewports.desktop = {
+      similarity: 0, error: 'element screenshot failed', weight: 1.0,
+    };
+  }
+} catch (err) {
+  results.viewports.desktop = {
+    similarity: 0, error: err.message, weight: 1.0,
+  };
+}
+
+try {
+  cli('close');
+} catch {
+  // Session may already be closed
+}
+
+results.compositeScore = results.viewports.desktop?.similarity || 0;
+
+console.log(JSON.stringify(results, null, 2));
+
+writeFileSync(
+  join(RESULTS_DIR, 'latest-evaluation.json'),
+  JSON.stringify(results, null, 2),
+);
+```
+
+- [ ] **Step 2: Verify template placeholders are consistent**
+
+Confirm these placeholders exist in the template:
+- `{{ROW_INDEX}}` — row number (0, 1, ...)
+- `{{ROW_SELECTOR}}` — CSS selector for the row element
+- `{{ROW_SESSION}}` — playwright-cli session name (e.g., `row-0-eval`)
+- `{{PORT}}`, `{{PAGE_PATH}}`, `{{SKILL_HOME}}` — shared with existing templates
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/migrate-header/templates/evaluate-row.js.tmpl
+git commit -m "feat(migrate-header): add per-row evaluator template"
+```
+
+---
+
+### Task 2: `loop-row.sh.tmpl` — Per-Row Loop Template
+
+**Files:**
+- Create: `skills/migrate-header/templates/loop-row.sh.tmpl`
+
+Per-row outer loop. Key differences from `loop.sh.tmpl`:
+- `HEADER_FILES="blocks/header/row-{{ROW_INDEX}}.css"` — only its own CSS file
+- File-scoped git ratchet: `git checkout -- blocks/header/row-N.css` instead of `reset --hard`
+- Results file: `results-row-{{ROW_INDEX}}.tsv`
+- Session names: `row-{{ROW_INDEX}}-judge` for judge
+- Commit messages: `row-{{ROW_INDEX}}-iteration-N: ...`
+- Scoring: `pixel * 0.50 + judge * 0.50` (no nav weight)
+
+- [ ] **Step 1: Create `loop-row.sh.tmpl`**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Per-row autoresearch loop for EDS header migration.
+# Scoped to row-{{ROW_INDEX}} — only modifies blocks/header/row-{{ROW_INDEX}}.css.
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EVALUATE="node ${PROJECT_DIR}/autoresearch/evaluate-row-{{ROW_INDEX}}.js"
+RESULTS_FILE="${PROJECT_DIR}/results-row-{{ROW_INDEX}}.tsv"
+PROGRAM_FILE="${PROJECT_DIR}/program-row-{{ROW_INDEX}}.md"
+PORT="${AEM_PORT:-{{PORT}}}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-{{MAX_ITERATIONS}}}"
+MAX_CONSECUTIVE_REVERTS="${MAX_CONSECUTIVE_REVERTS:-{{MAX_CONSECUTIVE_REVERTS}}}"
+ROW_CSS="blocks/header/row-{{ROW_INDEX}}.css"
+BEST_SCORE=0
+ITERATION=0
+CONSECUTIVE_REVERTS=0
+BEST_KEPT_ITERATION=0
+JUDGE_TMPL_DIR="{{SKILL_HOME}}/templates"
+JUDGE_NEUTRAL=$'50\t{"layout_ok":true,"precision_ok":false,"active_gate":1,"diagnosis":[],"structure_issues":[],"precision_issues":[],"reasoning":""}'
+ROW_RESULTS_DIR="${PROJECT_DIR}/autoresearch/results/row-{{ROW_INDEX}}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[row-{{ROW_INDEX}}]${NC} $1"; }
+ok()  { echo -e "${GREEN}[row-{{ROW_INDEX}}]${NC} $1"; }
+warn() { echo -e "${YELLOW}[row-{{ROW_INDEX}}]${NC} $1"; }
+err() { echo -e "${RED}[row-{{ROW_INDEX}}]${NC} $1"; }
+
+cleanup() {
+  echo ""
+  log "Stopping... Final best score: ${BEST_SCORE}"
+  if [[ -f "${RESULTS_FILE}" ]]; then
+    log "Results saved to ${RESULTS_FILE}"
+    log "Total iterations: ${ITERATION}"
+    log "Consecutive reverts at exit: ${CONSECUTIVE_REVERTS}"
+  fi
+  exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+mkdir -p "${ROW_RESULTS_DIR}"
+
+# Initialize results file
+if [[ ! -f "${RESULTS_FILE}" ]]; then
+  printf "iteration\tcommit\tscore\tvisual_desktop\tjudge\tstatus\tdescription\n" \
+    > "${RESULTS_FILE}"
+fi
+
+# Resume support: read best score and iteration count from existing results
+if [[ -f "${RESULTS_FILE}" ]]; then
+  existing_best=$(tail -n +2 "${RESULTS_FILE}" \
+    | awk -F'\t' '{print $3}' | sort -rn | head -1)
+  if [[ -n "${existing_best}" ]]; then
+    BEST_SCORE="${existing_best}"
+    ITERATION=$(tail -n +2 "${RESULTS_FILE}" | wc -l | tr -d ' ')
+    log "Resuming from iteration ${ITERATION}, best score: ${BEST_SCORE}"
+  fi
+fi
+
+# Check dev server is reachable
+check_server() {
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "http://localhost:${PORT}/" 2>/dev/null) || true
+  if [[ "${status}" != "200" ]]; then
+    err "Dev server not running on port ${PORT}."
+    err "Start it with: cd ${PROJECT_DIR} && aem up --html-folder ."
+    exit 1
+  fi
+}
+
+# Run evaluator and extract score
+run_evaluation() {
+  local eval_output
+  eval_output=$(${EVALUATE} "${PORT}" "${ITERATION}" 2>/dev/null) || true
+
+  if [[ -z "${eval_output}" ]]; then
+    echo "0"
+    return
+  fi
+
+  echo "${eval_output}" | node --input-type=commonjs -e "
+    const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    console.log(d.compositeScore||0);
+  " 2>/dev/null || echo "0"
+}
+
+# Run LLM judge: compare source + before + after row screenshots
+run_judge() {
+  local iteration=$1
+  local source_img="${PROJECT_DIR}/autoresearch/source/desktop-row-{{ROW_INDEX}}.png"
+  local styles_json="${PROJECT_DIR}/autoresearch/extraction/styles.json"
+  local css_query="{{SKILL_HOME}}/scripts/css-query.js"
+  local after_img="${ROW_RESULTS_DIR}/desktop-rendered-${iteration}.png"
+  local judge_prompt_file="/tmp/judge-row-{{ROW_INDEX}}-prompt-$$.md"
+
+  if [[ ! -f "${after_img}" ]]; then
+    warn "Judge: after screenshot not found, skipping"
+    printf '%s\n' "${JUDGE_NEUTRAL}"
+    return
+  fi
+
+  local common_seds=(
+    -e "s|{{SOURCE_IMG}}|${source_img}|g"
+    -e "s|{{AFTER_IMG}}|${after_img}|g"
+    -e "s|{{AFTER_ITERATION}}|${iteration}|g"
+    -e "s|{{STYLES_JSON}}|${styles_json}|g"
+    -e "s|{{CSS_QUERY}}|${css_query}|g"
+    -e "s|{{PORT}}|${PORT}|g"
+  )
+
+  if [[ ${BEST_KEPT_ITERATION} -eq 0 ]]; then
+    local tmpl="${JUDGE_TMPL_DIR}/judge-first.md.tmpl"
+    if [[ ! -f "${tmpl}" ]]; then
+      warn "Judge: first-iteration template not found, skipping"
+      printf '%s\n' "${JUDGE_NEUTRAL}"
+      return
+    fi
+    sed "${common_seds[@]}" "${tmpl}" > "${judge_prompt_file}"
+  else
+    local before_img="${ROW_RESULTS_DIR}/desktop-rendered-${BEST_KEPT_ITERATION}.png"
+    local tmpl="${JUDGE_TMPL_DIR}/judge.md.tmpl"
+    if [[ ! -f "${tmpl}" ]]; then
+      warn "Judge: template not found, skipping"
+      printf '%s\n' "${JUDGE_NEUTRAL}"
+      return
+    fi
+    if [[ ! -f "${before_img}" ]]; then
+      warn "Judge: before screenshot not found, using first-iteration template"
+      tmpl="${JUDGE_TMPL_DIR}/judge-first.md.tmpl"
+      sed "${common_seds[@]}" "${tmpl}" > "${judge_prompt_file}"
+    else
+      sed "${common_seds[@]}" \
+          -e "s|{{BEFORE_IMG}}|${before_img}|g" \
+          -e "s|{{BEFORE_ITERATION}}|${BEST_KEPT_ITERATION}|g" \
+          "${tmpl}" > "${judge_prompt_file}"
+    fi
+  fi
+
+  # Open css-query session on rendered page for Gate 2
+  node "${css_query}" open "http://localhost:${PORT}/" --session=row-{{ROW_INDEX}}-judge 2>/dev/null || true
+
+  local judge_raw
+  judge_raw=$(claude -p "$(cat "${judge_prompt_file}")" \
+    --allowedTools "Read,Bash" \
+    --output-format json 2>"${ROW_RESULTS_DIR}/judge-stderr.log") || true
+  rm -f "${judge_prompt_file}"
+
+  node "${css_query}" close --session=row-{{ROW_INDEX}}-judge 2>/dev/null || true
+
+  if [[ -z "${judge_raw}" ]]; then
+    warn "Judge: no output, defaulting to neutral"
+    printf '%s\n' "${JUDGE_NEUTRAL}"
+    return
+  fi
+
+  echo "${judge_raw}" | node --input-type=commonjs -e "
+    const raw = require('fs').readFileSync('/dev/stdin', 'utf-8').trim();
+    try {
+      const envelope = JSON.parse(raw);
+      const d = JSON.parse(envelope.result);
+      const score = d.improved === true ? 100 : (d.improved === false ? 0 : 50);
+      const detail = JSON.stringify({
+        layout_ok: d.layout_ok === true,
+        precision_ok: d.precision_ok === true,
+        active_gate: d.active_gate || 1,
+        diagnosis: d.diagnosis || [],
+        structure_issues: d.structure_issues || [],
+        precision_issues: d.precision_issues || [],
+        reasoning: d.reasoning || '',
+      });
+      console.log(score + '\t' + detail);
+    } catch {
+      console.log('50\t' + JSON.stringify({layout_ok:true,precision_ok:false,active_gate:1,diagnosis:[],structure_issues:[],precision_issues:[],reasoning:''}));
+    }
+  " 2>/dev/null || printf '%s\n' "${JUDGE_NEUTRAL}"
+}
+
+# Main loop
+log "Starting row-{{ROW_INDEX}} polish loop"
+log "Max iterations: ${MAX_ITERATIONS}"
+log "Plateau threshold: ${MAX_CONSECUTIVE_REVERTS} consecutive reverts"
+log "Evaluator: ${EVALUATE}"
+echo ""
+
+check_server
+
+while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
+  ITERATION=$((ITERATION + 1))
+  log "=== Iteration ${ITERATION}/${MAX_ITERATIONS} (best: ${BEST_SCORE}, reverts: ${CONSECUTIVE_REVERTS}/${MAX_CONSECUTIVE_REVERTS}) ==="
+
+  # Snapshot row CSS before agent session
+  cp "${PROJECT_DIR}/${ROW_CSS}" "/tmp/row-{{ROW_INDEX}}-backup-$$.css" 2>/dev/null || true
+
+  # Fresh claude session with row program
+  log "Launching fresh Claude session..."
+  (cd "${PROJECT_DIR}" && claude -p "$(cat "${PROGRAM_FILE}")" \
+    --allowedTools "Edit,Write,Read,Glob,Grep,Bash" \
+    > /dev/null 2>&1) || true
+
+  # Check if row CSS changed
+  has_changes=false
+  if ! diff -q "${PROJECT_DIR}/${ROW_CSS}" "/tmp/row-{{ROW_INDEX}}-backup-$$.css" \
+    >/dev/null 2>&1; then
+    has_changes=true
+  fi
+
+  if [[ "${has_changes}" == "false" ]]; then
+    warn "No changes detected, skipping evaluation"
+    printf "%d\t-\t%s\t-\t-\tno_changes\tAgent made no modifications\n" \
+      "${ITERATION}" "${BEST_SCORE}" >> "${RESULTS_FILE}"
+    CONSECUTIVE_REVERTS=$((CONSECUTIVE_REVERTS + 1))
+    if [[ ${CONSECUTIVE_REVERTS} -ge ${MAX_CONSECUTIVE_REVERTS} ]]; then
+      err "Plateau: ${CONSECUTIVE_REVERTS} consecutive non-improvements. Stopping."
+      break
+    fi
+    continue
+  fi
+
+  # Stage and commit the row CSS
+  git -C "${PROJECT_DIR}" add "${ROW_CSS}" 2>/dev/null || true
+  git -C "${PROJECT_DIR}" commit \
+    -m "row-{{ROW_INDEX}}-iteration-${ITERATION}: agent modifications" \
+    2>/dev/null || true
+
+  local_commit=$(git -C "${PROJECT_DIR}" rev-parse --short HEAD)
+  commit_msg=$(git -C "${PROJECT_DIR}" log -1 --format=%s)
+
+  # Run immutable evaluator
+  log "Running evaluation..."
+  desktop=$(run_evaluation)
+
+  # Run LLM judge
+  log "Running judge comparison..."
+  judge_result=$(run_judge "${ITERATION}")
+  IFS=$'\t' read -r judge_score judge_detail <<< "${judge_result}"
+
+  # Write judge feedback for next iteration
+  echo "${judge_detail}" > "${ROW_RESULTS_DIR}/judge-feedback.json"
+
+  # Composite: pixelmatch 50% + judge 50% (no nav weight)
+  score=$(node -e "
+    const pm = ${desktop} || 0;
+    const judge = ${judge_score} || 50;
+    console.log(Math.round((pm * 0.50 + judge * 0.50) * 100) / 100);
+  " 2>/dev/null || echo "0")
+
+  keep=$(node -e "console.log(${score} > ${BEST_SCORE} ? 'yes' : 'no')" \
+    2>/dev/null || echo "no")
+
+  if [[ "${keep}" == "yes" ]]; then
+    iteration_status="kept"
+    ok "IMPROVED: ${BEST_SCORE} -> ${score} (desktop=${desktop}, judge=${judge_score})"
+    BEST_SCORE="${score}"
+    BEST_KEPT_ITERATION=${ITERATION}
+    CONSECUTIVE_REVERTS=0
+    printf "%d\t%s\t%s\t%s\t%s\timproved\t%s\n" \
+      "${ITERATION}" "${local_commit}" "${score}" \
+      "${desktop}" "${judge_score}" \
+      "${commit_msg}" \
+      >> "${RESULTS_FILE}"
+  else
+    iteration_status="reverted"
+    warn "NO IMPROVEMENT: ${score} <= ${BEST_SCORE} (judge=${judge_score}) — reverting"
+    # File-scoped revert — does not affect other rows
+    git -C "${PROJECT_DIR}" checkout -- "${ROW_CSS}" 2>/dev/null || true
+    # Also revert the commit
+    git -C "${PROJECT_DIR}" reset --soft HEAD~1 2>/dev/null || true
+    git -C "${PROJECT_DIR}" checkout -- "${ROW_CSS}" 2>/dev/null || true
+    CONSECUTIVE_REVERTS=$((CONSECUTIVE_REVERTS + 1))
+    printf "%d\t%s\t%s\t%s\t%s\treverted\t%s\n" \
+      "${ITERATION}" "${local_commit}" "${score}" \
+      "${desktop}" "${judge_score}" \
+      "${commit_msg}" \
+      >> "${RESULTS_FILE}"
+
+    if [[ ${CONSECUTIVE_REVERTS} -ge ${MAX_CONSECUTIVE_REVERTS} ]]; then
+      err "Plateau: ${CONSECUTIVE_REVERTS} consecutive non-improvements. Stopping."
+      break
+    fi
+  fi
+
+  # Append to cumulative judge history
+  node -e "
+    const fs = require('fs');
+    const detail = JSON.parse(process.argv[1] || '{}');
+    const entry = {
+      ...detail,
+      iteration: ${ITERATION},
+      composite: ${score},
+      desktop: ${desktop},
+      judge: ${judge_score},
+      status: '${iteration_status}',
+    };
+    fs.appendFileSync(
+      '${ROW_RESULTS_DIR}/judge-history.jsonl',
+      JSON.stringify(entry) + '\n'
+    );
+  " "${judge_detail}" 2>/dev/null || true
+
+  rm -f "/tmp/row-{{ROW_INDEX}}-backup-$$.css"
+  echo ""
+done
+
+rm -f "/tmp/row-{{ROW_INDEX}}-backup-$$.css"
+log "Row-{{ROW_INDEX}} loop finished. Best score: ${BEST_SCORE} after ${ITERATION} iterations."
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/migrate-header/templates/loop-row.sh.tmpl
+git commit -m "feat(migrate-header): add per-row loop template"
+```
+
+---
+
+### Task 3: `program-row.md.tmpl` — Per-Row Polish Agent Prompt
+
+**Files:**
+- Create: `skills/migrate-header/templates/program-row.md.tmpl`
+
+Scoped version of `program.md.tmpl`. Key differences:
+- Agent owns only `blocks/header/row-{{ROW_INDEX}}.css`
+- Cannot modify `header.css`, `header.js`, `nav.plain.html`, or other row files
+- Scoring explanation: pixelmatch 50% + judge 50%
+- Source reference uses `desktop-row-{{ROW_INDEX}}.png`
+- Results at `autoresearch/results/row-{{ROW_INDEX}}/`
+- Row-specific description and visual tree subtree
+- CSS query session: `row-{{ROW_INDEX}}-css-src`
+
+- [ ] **Step 1: Create `program-row.md.tmpl`**
+
+```markdown
+# Row {{ROW_INDEX}} Migration — Autoresearch Program
+
+## Goal
+
+Polish row {{ROW_INDEX}} of the header from {{URL}} to match the source with maximum visual fidelity.
+
+**Your row:**
+{{ROW_DESCRIPTION}}
+
+**Row height: ~{{ROW_HEIGHT}}px at desktop.** Matching this height is critical for the visual score.
+
+## Your Environment
+
+- AEM Edge Delivery Services dev server running at http://localhost:{{PORT}}
+- Content served from project root via `aem up --html-folder .`
+- Test page: http://localhost:{{PORT}}/
+- Your row is rendered via section-metadata class `{{ROW_SECTION_STYLE}}`
+
+## What You CAN Modify
+
+You may ONLY modify this one file:
+
+1. `blocks/header/row-{{ROW_INDEX}}.css` — Your row's styles
+
+## What You CANNOT Modify
+
+Everything else is off-limits. In particular:
+- `blocks/header/header.css` — imports row files, managed by orchestrator
+- `blocks/header/header.js` — shared decoration logic
+- `blocks/header/row-*.css` (other rows) — owned by other agents
+- `nav.plain.html` — shared nav structure
+- `autoresearch/` — evaluation infrastructure (immutable)
+- `loop-row-*.sh`, `program-row-*.md` — loop infrastructure
+- `scripts/`, `styles/` — EDS core files
+
+## How to Read History
+
+Before making changes, ALWAYS review what has been tried:
+1. `cat results-row-{{ROW_INDEX}}.tsv` — Full experiment log (iteration, score, status, description)
+2. `cat autoresearch/results/row-{{ROW_INDEX}}/latest-evaluation.json` — Last evaluation breakdown
+3. **Read the diff image** — `autoresearch/results/row-{{ROW_INDEX}}/desktop-diff.png` shows pixel-level mismatches. Read this image to see WHERE the differences are.
+4. `cat autoresearch/results/row-{{ROW_INDEX}}/judge-feedback.json` (if exists) — Judge assessment from previous iteration
+
+If results show repeated reverts for similar approaches, try something fundamentally different.
+
+## Judge Feedback
+
+If `autoresearch/results/row-{{ROW_INDEX}}/judge-feedback.json` exists, read it FIRST.
+It contains a three-gate assessment from the previous iteration. See the gate descriptions:
+
+- **Gate 1 (`layout_ok: false`)** — structural layout is wrong. Fix element positions, sizes, order.
+- **Gate 2 (`precision_ok: false`)** — layout correct but fonts, sizes, dimensions don't match. Fix specific CSS values.
+- **Gate 3 (both ok)** — structure and precision correct. Fix colors, spacing, decorative details.
+
+Fix issues from the **active gate** only.
+
+## How the Evaluator Scores You
+
+After you exit, two evaluations run:
+
+1. **Pixelmatch evaluator** — screenshots your row element and compares against the source row screenshot
+2. **LLM judge** — compares source, previous best, and current render
+
+The composite score (0-100) combines:
+- **50% weight**: Visual similarity via pixelmatch
+- **50% weight**: LLM judge (improved? YES=100, NO=0)
+
+The outer loop keeps your changes if the score improves, reverts if it doesn't.
+
+## Source Reference
+
+- `autoresearch/source/desktop-row-{{ROW_INDEX}}.png` — Cropped screenshot of source row at 1440px
+
+## Source Visual Tree (your row only)
+
+```
+{{ROW_VISUAL_TREE}}
+```
+
+## CSS Query Tool
+
+Query the source page's actual CSS values:
+
+```bash
+node "{{SKILL_HOME}}/scripts/css-query.js" open "{{URL}}" --session=row-{{ROW_INDEX}}-css-src
+node "{{SKILL_HOME}}/scripts/css-query.js" query "<selector>" "<properties>" --session=row-{{ROW_INDEX}}-css-src
+node "{{SKILL_HOME}}/scripts/css-query.js" close --session=row-{{ROW_INDEX}}-css-src
+```
+
+## Available Icons
+
+{{ICON_GUIDANCE}}
+
+## Constraints
+
+1. **CSS only.** You can only edit `row-{{ROW_INDEX}}.css`. No JS changes.
+2. **The row must render.** A broken row scores 0. Prefer incremental progress.
+3. **Commit before exiting.** `git add blocks/header/row-{{ROW_INDEX}}.css && git commit -m "description"`
+4. **Read results first.** Do not repeat approaches that were reverted.
+
+## Strategy
+
+Open a CSS query session at the start of every iteration:
+```bash
+node "{{SKILL_HOME}}/scripts/css-query.js" open "{{URL}}" --session=row-{{ROW_INDEX}}-css-src
+```
+
+### Phase 1: Structure (score < 30)
+Get elements rendering in the correct positions within the row.
+
+### Phase 2: Dimensions (score 30-50)
+Match the row height (~{{ROW_HEIGHT}}px). Query source for exact values.
+
+### Phase 3: Colors and layout (score 50-70)
+Query source for exact colors, spacing, alignment values.
+
+### Phase 4: Visual polish (score > 70)
+Query specific properties for pixel-accurate matching.
+
+## NEVER STOP
+
+Continue working until you have made your changes and committed them. Then exit cleanly.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add skills/migrate-header/templates/program-row.md.tmpl
+git commit -m "feat(migrate-header): add per-row program prompt template"
+```
+
+---
+
+### Task 4: `setup-polish-loop.js` — Add `--init-css` and `--row=N` Flags
+
+**Files:**
+- Modify: `skills/migrate-header/scripts/setup-polish-loop.js`
+- Test: `tests/migrate-header/setup-polish-loop.test.js`
+
+Add two new modes to the existing setup script:
+1. `--init-css` — generates `header.css` with `@import` rules and empty `row-N.css` stubs
+2. `--row=N` — generates per-row loop infrastructure (evaluator, loop script, program prompt)
+
+The existing mode (no `--row`, no `--init-css`) stays unchanged for reconciliation.
+
+- [ ] **Step 1: Write tests for `cropSourceRow`**
+
+Add to `tests/migrate-header/setup-polish-loop.test.js`:
+
+```javascript
+import {
+  loadRowFiles,
+  buildHeaderDescription,
+  countNavItems,
+  buildNavStructure,
+  synthesizeStyles,
+  cropSourceRow,
+  generateInitCss,
+  buildRowReplacements,
+} from '../../skills/migrate-header/scripts/setup-polish-loop.js';
+
+// ... existing tests ...
+
+describe('cropSourceRow', () => {
+  it('crops a PNG to the specified row bounds', () => {
+    // Create a 100x100 red PNG in memory
+    const { PNG } = await import('pngjs');
+    const img = new PNG({ width: 100, height: 100 });
+    for (let i = 0; i < img.data.length; i += 4) {
+      img.data[i] = 255;     // R
+      img.data[i + 1] = 0;   // G
+      img.data[i + 2] = 0;   // B
+      img.data[i + 3] = 255; // A
+    }
+    const sourceBuf = PNG.sync.write(img);
+
+    const result = cropSourceRow(sourceBuf, { y: 10, height: 30 }, 100);
+    const cropped = PNG.sync.read(result);
+    expect(cropped.width).toBe(100);
+    expect(cropped.height).toBe(30);
+  });
+
+  it('clamps bounds that exceed image dimensions', () => {
+    const { PNG } = await import('pngjs');
+    const img = new PNG({ width: 50, height: 50 });
+    for (let i = 0; i < img.data.length; i += 4) {
+      img.data[i] = 0;
+      img.data[i + 1] = 0;
+      img.data[i + 2] = 255;
+      img.data[i + 3] = 255;
+    }
+    const sourceBuf = PNG.sync.write(img);
+
+    const result = cropSourceRow(sourceBuf, { y: 40, height: 30 }, 50);
+    const cropped = PNG.sync.read(result);
+    expect(cropped.width).toBe(50);
+    expect(cropped.height).toBe(10); // clamped to 50-40
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/migrate-header/setup-polish-loop.test.js`
+Expected: FAIL — `cropSourceRow` is not exported
+
+- [ ] **Step 3: Write tests for `generateInitCss`**
+
+```javascript
+describe('generateInitCss', () => {
+  it('generates @import rules for each row', () => {
+    const rows = loadFixtures();
+    const css = generateInitCss(rows);
+    expect(css).toContain("@import url('row-0.css');");
+    expect(css).toContain("@import url('row-1.css');");
+  });
+
+  it('preserves row order', () => {
+    const rows = loadFixtures();
+    const css = generateInitCss(rows);
+    const idx0 = css.indexOf('row-0.css');
+    const idx1 = css.indexOf('row-1.css');
+    expect(idx0).toBeLessThan(idx1);
+  });
+});
+```
+
+- [ ] **Step 4: Write tests for `buildRowReplacements`**
+
+```javascript
+describe('buildRowReplacements', () => {
+  it('returns row-specific template values', () => {
+    const rows = loadFixtures();
+    const r = buildRowReplacements(rows[0], {
+      port: '3000',
+      maxIterations: '30',
+      url: 'https://example.com',
+      skillHome: '/path/to/skill',
+    });
+    expect(r['{{ROW_INDEX}}']).toBe('0');
+    expect(r['{{ROW_SELECTOR}}']).toBeDefined();
+    expect(r['{{ROW_SESSION}}']).toBe('row-0-eval');
+    expect(r['{{ROW_HEIGHT}}']).toBe('44');
+    expect(r['{{ROW_SECTION_STYLE}}']).toBe('brand');
+  });
+});
+```
+
+- [ ] **Step 5: Run tests to verify they fail**
+
+Run: `npx vitest run tests/migrate-header/setup-polish-loop.test.js`
+Expected: FAIL — functions not exported
+
+- [ ] **Step 6: Implement `cropSourceRow` in `setup-polish-loop.js`**
+
+Add after the existing `synthesizeStyles` function:
+
+```javascript
+export function cropSourceRow(pngBuffer, bounds, sourceWidth) {
+  const { PNG } = await import('pngjs');
+  // Use dynamic import at call site — PNG is only needed for cropping
+  const source = PNG.sync.read(pngBuffer);
+  const y = Math.round(bounds.y);
+  const h = Math.min(
+    Math.round(bounds.height),
+    source.height - y,
+  );
+  const w = Math.min(sourceWidth, source.width);
+
+  const cropped = new PNG({ width: w, height: h });
+  for (let row = 0; row < h; row++) {
+    for (let col = 0; col < w; col++) {
+      const srcIdx = ((y + row) * source.width + col) * 4;
+      const dstIdx = (row * w + col) * 4;
+      cropped.data[dstIdx] = source.data[srcIdx];
+      cropped.data[dstIdx + 1] = source.data[srcIdx + 1];
+      cropped.data[dstIdx + 2] = source.data[srcIdx + 2];
+      cropped.data[dstIdx + 3] = source.data[srcIdx + 3];
+    }
+  }
+  return PNG.sync.write(cropped);
+}
+```
+
+Note: `cropSourceRow` needs `pngjs` which is installed by the evaluator's npm init step. Since this runs at setup time before that, we need to handle this. Two options: (a) use the `pngjs` already installed in autoresearch/ after npm init, or (b) import it dynamically. Since `setup-polish-loop.js` runs after directory creation but before the evaluator npm init, we should install pngjs early or use a simpler approach.
+
+**Simpler approach — use the existing `cropHeaderFromScreenshot` logic inline with `sharp` or just re-use pngjs by ensuring it's available.** The cleanest path: move `npm init` + `npm install pixelmatch pngjs` to happen before per-row setup calls. This is already the case since `--init-css` runs first and can do the npm install, then `--row=N` calls can import pngjs.
+
+Actually, the simplest approach: `cropSourceRow` accepts a parsed PNG object instead of a buffer, and the caller handles pngjs import. But since this is a setup script that runs on the developer's machine (not in the EDS project), we can just add pngjs as a dependency of the script itself. However, the skill's scripts don't have their own package.json.
+
+**Revised approach:** Do the cropping in `--init-css` mode (which runs first), using a child process that calls into the autoresearch dir where pngjs is installed. OR, simpler: use Node's built-in capabilities. Since we're just slicing a PNG, we can shell out to `ffmpeg` which is already a dependency of the skill ecosystem:
+
+```bash
+ffmpeg -i source/desktop.png -vf "crop=in_w:ROW_HEIGHT:0:ROW_Y" source/desktop-row-N.png
+```
+
+But that adds an ffmpeg dependency to header migration which doesn't otherwise need it.
+
+**Final approach:** Have `--init-css` also run `npm init -y && npm install pixelmatch pngjs` in the autoresearch dir (moving it from the default mode). Then `--row=N` can import pngjs from there. This is the cleanest split.
+
+- [ ] **Step 7: Implement `generateInitCss`**
+
+```javascript
+export function generateInitCss(rows) {
+  const imports = rows.map(
+    (_, i) => `@import url('row-${i}.css');`,
+  );
+  return imports.join('\n') + '\n';
+}
+```
+
+- [ ] **Step 8: Implement `buildRowReplacements`**
+
+```javascript
+export function buildRowReplacements(row, opts) {
+  return {
+    '{{ROW_INDEX}}': String(row.index),
+    '{{ROW_SELECTOR}}': row.selector || `header > :nth-child(${row.index + 1})`,
+    '{{ROW_SESSION}}': `row-${row.index}-eval`,
+    '{{ROW_HEIGHT}}': String(Math.round(row.bounds.height)),
+    '{{ROW_SECTION_STYLE}}': row.suggestedSectionStyle || `row-${row.index}`,
+    '{{ROW_DESCRIPTION}}': row.description || `Row ${row.index}`,
+    '{{ROW_VISUAL_TREE}}': row.vtSubtree || 'Visual tree not available.',
+    '{{PORT}}': opts.port,
+    '{{PAGE_PATH}}': '/',
+    '{{MAX_ITERATIONS}}': opts.maxIterations,
+    '{{MAX_CONSECUTIVE_REVERTS}}': '5',
+    '{{URL}}': opts.url,
+    '{{SKILL_HOME}}': opts.skillHome,
+    '{{ICON_GUIDANCE}}': opts.iconGuidance || '',
+  };
+}
+```
+
+- [ ] **Step 9: Add `--init-css` mode to `parseArgs` and `main`**
+
+Update `parseArgs` to accept `--init-css` and `--row` flags:
+
+```javascript
+function parseArgs(argv) {
+  const named = {};
+  for (const arg of argv.slice(2)) {
+    const m = arg.match(/^--([a-z-]+)=(.+)$/);
+    if (m) named[m[1]] = m[2];
+    // Boolean flags (no =value)
+    if (arg === '--init-css') named['init-css'] = 'true';
+  }
+
+  const initCss = named['init-css'] === 'true';
+  const rowIndex = named['row'] !== undefined ? parseInt(named['row'], 10) : null;
+
+  if (initCss) {
+    // --init-css only needs rows-dir and target-dir
+    const required = ['rows-dir', 'target-dir'];
+    const missing = required.filter((k) => !named[k]);
+    if (missing.length > 0) {
+      console.error(`Missing: ${missing.map((k) => `--${k}`).join(', ')}`);
+      process.exit(1);
+    }
+    return { mode: 'init-css', rowsDir: resolve(named['rows-dir']), targetDir: resolve(named['target-dir']) };
+  }
+
+  // Full mode (--row=N or default reconciliation)
+  const required = ['rows-dir', 'url', 'source-dir', 'target-dir'];
+  const missing = required.filter((k) => !named[k]);
+  if (missing.length > 0) {
+    console.error(`Missing: ${missing.map((k) => `--${k}`).join(', ')}`);
+    process.exit(1);
+  }
+
+  return {
+    mode: rowIndex !== null ? 'row' : 'full',
+    rowIndex,
+    rowsDir: resolve(named['rows-dir']),
+    url: named['url'],
+    sourceDir: resolve(named['source-dir']),
+    targetDir: resolve(named['target-dir']),
+    explicitPort: named['port'] || null,
+    maxIterations: named['max-iterations'] || '30',
+    skillHome: named['skill-home'] || join(__dirname, '..'),
+  };
+}
+```
+
+- [ ] **Step 10: Add `mainInitCss` function**
+
+```javascript
+function mainInitCss(args) {
+  const rows = loadRowFiles(args.rowsDir);
+  if (rows.length === 0) {
+    console.error(`No row-*.json files found in: ${args.rowsDir}`);
+    process.exit(1);
+  }
+
+  const headerDir = join(args.targetDir, 'blocks', 'header');
+  mkdirSync(headerDir, { recursive: true });
+
+  // Create empty row-N.css stubs
+  for (let i = 0; i < rows.length; i++) {
+    const rowCssPath = join(headerDir, `row-${i}.css`);
+    if (!existsSync(rowCssPath)) {
+      writeFileSync(rowCssPath, `/* Row ${i}: ${rows[i].description || ''} */\n`);
+      log(`  Created blocks/header/row-${i}.css`);
+    }
+  }
+
+  // Write header.css with @import rules
+  const headerCssPath = join(headerDir, 'header.css');
+  let existingContent = '';
+  if (existsSync(headerCssPath)) {
+    existingContent = readFileSync(headerCssPath, 'utf-8');
+  }
+
+  // Remove any existing @import row lines, preserve other content
+  const nonImportLines = existingContent
+    .split('\n')
+    .filter((line) => !line.match(/^@import url\('row-\d+\.css'\);/))
+    .join('\n')
+    .trim();
+
+  const importBlock = generateInitCss(rows);
+  const finalCss = importBlock + (nonImportLines ? '\n\n' + nonImportLines + '\n' : '');
+  writeFileSync(headerCssPath, finalCss);
+  log(`  Wrote blocks/header/header.css with ${rows.length} @import rules`);
+
+  // Install npm dependencies for evaluator (needed by --row mode for cropping)
+  const autoresearchDir = join(args.targetDir, 'autoresearch');
+  mkdirSync(autoresearchDir, { recursive: true });
+  execSync('npm init -y', { cwd: autoresearchDir, stdio: 'pipe' });
+  const pkgPath = join(autoresearchDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  pkg.type = 'module';
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  execSync('npm install pixelmatch pngjs', { cwd: autoresearchDir, stdio: 'pipe' });
+  log('  Installed pixelmatch + pngjs in autoresearch/');
+
+  log(`Init CSS complete: ${rows.length} rows.`);
+}
+```
+
+- [ ] **Step 11: Add `mainRow` function**
+
+```javascript
+async function mainRow(args) {
+  const rows = loadRowFiles(args.rowsDir);
+  const row = rows.find((r) => r.index === args.rowIndex);
+  if (!row) {
+    console.error(`Row ${args.rowIndex} not found in ${args.rowsDir}`);
+    process.exit(1);
+  }
+
+  const port = detectPort(args.targetDir, args.explicitPort);
+
+  // Crop source screenshot for this row
+  const sourceDesktop = join(args.sourceDir, 'desktop.png');
+  if (existsSync(sourceDesktop)) {
+    const pngjsPath = join(args.targetDir, 'autoresearch', 'node_modules', 'pngjs', 'lib', 'pngjs.js');
+    const { PNG } = await import(pngjsPath);
+    const sourceBuf = readFileSync(sourceDesktop);
+    const sourceImg = PNG.sync.read(sourceBuf);
+    const y = Math.round(row.bounds.y);
+    const h = Math.min(Math.round(row.bounds.height), sourceImg.height - y);
+    const w = sourceImg.width;
+
+    const cropped = new PNG({ width: w, height: h });
+    for (let r = 0; r < h; r++) {
+      for (let c = 0; c < w; c++) {
+        const srcIdx = ((y + r) * sourceImg.width + c) * 4;
+        const dstIdx = (r * w + c) * 4;
+        cropped.data[dstIdx] = sourceImg.data[srcIdx];
+        cropped.data[dstIdx + 1] = sourceImg.data[srcIdx + 1];
+        cropped.data[dstIdx + 2] = sourceImg.data[srcIdx + 2];
+        cropped.data[dstIdx + 3] = sourceImg.data[srcIdx + 3];
+      }
+    }
+
+    const sourceOutDir = join(args.targetDir, 'autoresearch', 'source');
+    mkdirSync(sourceOutDir, { recursive: true });
+    writeFileSync(
+      join(sourceOutDir, `desktop-row-${args.rowIndex}.png`),
+      PNG.sync.write(cropped),
+    );
+    log(`  Cropped source row ${args.rowIndex}: ${w}x${h}px`);
+  }
+
+  // Build row-specific replacements
+  const replacements = buildRowReplacements(row, {
+    port,
+    maxIterations: args.maxIterations,
+    url: args.url,
+    skillHome: args.skillHome,
+    iconGuidance: buildIconGuidance(args.targetDir),
+  });
+
+  // Load row templates
+  const evaluateTmpl = loadTemplate('evaluate-row.js.tmpl');
+  const loopTmpl = loadTemplate('loop-row.sh.tmpl');
+  const programTmpl = loadTemplate('program-row.md.tmpl');
+
+  function applyReplacements(template) {
+    let result = template;
+    for (const [key, value] of Object.entries(replacements)) {
+      while (result.includes(key)) {
+        result = result.replace(key, value);
+      }
+    }
+    return result;
+  }
+
+  const autoresearchDir = join(args.targetDir, 'autoresearch');
+  const rowResultsDir = join(autoresearchDir, 'results', `row-${args.rowIndex}`);
+  mkdirSync(rowResultsDir, { recursive: true });
+
+  // Write per-row evaluator
+  writeFileSync(
+    join(autoresearchDir, `evaluate-row-${args.rowIndex}.js`),
+    applyReplacements(evaluateTmpl),
+  );
+  log(`  Wrote autoresearch/evaluate-row-${args.rowIndex}.js`);
+
+  // Write per-row loop script
+  const loopPath = join(args.targetDir, `loop-row-${args.rowIndex}.sh`);
+  writeFileSync(loopPath, applyReplacements(loopTmpl));
+  chmodSync(loopPath, 0o755);
+  log(`  Wrote loop-row-${args.rowIndex}.sh`);
+
+  // Write per-row program prompt
+  writeFileSync(
+    join(args.targetDir, `program-row-${args.rowIndex}.md`),
+    applyReplacements(programTmpl),
+  );
+  log(`  Wrote program-row-${args.rowIndex}.md`);
+
+  log(`Row ${args.rowIndex} infrastructure ready.`);
+}
+```
+
+- [ ] **Step 12: Update `main` to dispatch by mode**
+
+Replace the existing `main()` function body's first lines to branch on mode:
+
+```javascript
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.mode === 'init-css') {
+    mainInitCss(args);
+    return;
+  }
+
+  if (args.mode === 'row') {
+    await mainRow(args);
+    return;
+  }
+
+  // Existing full-header mode (reconciliation) — unchanged below this line
+  const rows = loadRowFiles(args.rowsDir);
+  // ... rest of existing main() ...
+}
+```
+
+Also update the entry point at the bottom of the file:
+
+```javascript
+const isDirectRun = process.argv[1]
+  && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 13: Remove npm install from existing `main` (now in `mainInitCss`)**
+
+In the existing full-header mode (now reached only for reconciliation), remove the npm init/install block (lines 367-380) since `--init-css` already handles it. Replace with a check:
+
+```javascript
+// Verify npm deps exist (installed by --init-css)
+const pngjsCheck = join(autoresearchDir, 'node_modules', 'pngjs');
+if (!existsSync(pngjsCheck)) {
+  log('Installing evaluator dependencies...');
+  execSync('npm init -y', { cwd: autoresearchDir, stdio: 'pipe' });
+  const pkgPath = join(autoresearchDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  pkg.type = 'module';
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  execSync('npm install pixelmatch pngjs', { cwd: autoresearchDir, stdio: 'pipe' });
+  log('  Installed pixelmatch + pngjs');
+}
+```
+
+- [ ] **Step 14: Export new functions**
+
+Add to the existing exports at the top-level scope:
+
+```javascript
+export { cropSourceRow, generateInitCss, buildRowReplacements };
+```
+
+- [ ] **Step 15: Run all tests**
+
+Run: `npx vitest run tests/migrate-header/setup-polish-loop.test.js`
+Expected: All tests pass (existing + new)
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add skills/migrate-header/scripts/setup-polish-loop.js tests/migrate-header/setup-polish-loop.test.js
+git commit -m "feat(migrate-header): add --init-css and --row flags to setup script"
+```
+
+---
+
+### Task 5: Add `selector` Field to Row Fixtures
+
+**Files:**
+- Modify: `tests/migrate-header/fixtures/row-0.json`
+- Modify: `tests/migrate-header/fixtures/row-1.json`
+
+The `buildRowReplacements` function reads `row.selector`. The existing fixtures don't have this field. Add it so tests work.
+
+- [ ] **Step 1: Add `selector` to fixtures**
+
+In `row-0.json`, add after `"index": 0,`:
+```json
+"selector": "header > div:nth-child(1)",
+```
+
+In `row-1.json`, add after `"index": 1,`:
+```json
+"selector": "header > div:nth-child(2)",
+```
+
+- [ ] **Step 2: Run tests to verify nothing broke**
+
+Run: `npx vitest run tests/migrate-header/setup-polish-loop.test.js`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/migrate-header/fixtures/row-0.json tests/migrate-header/fixtures/row-1.json
+git commit -m "test(migrate-header): add selector field to row fixtures"
+```
+
+---
+
+### Task 6: SKILL.md Phase 5 Rewrite
+
+**Files:**
+- Modify: `skills/migrate-header/SKILL.md` (lines 823–901)
+
+Replace Phase 5 with three sub-phases: setup, parallel row dispatch, adaptive reconciliation.
+
+- [ ] **Step 1: Replace Phase 5 section (lines 823–901)**
+
+Replace everything from `### Phase 5: Visual Polish` through `Mark Phase 5 as completed. Then proceed to Phase 6 — do NOT stop here.` with:
+
+```markdown
+### Phase 5: Visual Polish
+
+Mark Phase 5 as in_progress.
+
+#### 5.1 Polish Loop Setup
+
+**Initialize per-row CSS structure:**
+
+```bash
+node "$SKILL_HOME/scripts/setup-polish-loop.js" \
+  "--init-css" \
+  "--rows-dir=$PROJECT_ROOT/autoresearch/extraction" \
+  "--target-dir=$PROJECT_ROOT"
+```
+
+**Generate per-row loop infrastructure** — run once for each row in `rows.json`:
+
+```bash
+ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
+ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).length)")
+
+for i in $(seq 0 $((ROW_COUNT - 1))); do
+  node "$SKILL_HOME/scripts/setup-polish-loop.js" \
+    "--row=$i" \
+    "--rows-dir=$PROJECT_ROOT/autoresearch/extraction" \
+    "--url=$URL" \
+    "--source-dir=$PROJECT_ROOT/autoresearch/source" \
+    "--target-dir=$PROJECT_ROOT" \
+    "--port=3000" \
+    "--max-iterations=$MAX_ITERATIONS" \
+    "--skill-home=$SKILL_HOME"
+done
+```
+
+**Generate full-header infrastructure for reconciliation:**
+
+```bash
+node "$SKILL_HOME/scripts/setup-polish-loop.js" \
+  "--rows-dir=$PROJECT_ROOT/autoresearch/extraction" \
+  "--url=$URL" \
+  "--source-dir=$PROJECT_ROOT/autoresearch/source" \
+  "--target-dir=$PROJECT_ROOT" \
+  "--port=3000" \
+  "--max-iterations=5" \
+  "--skill-home=$SKILL_HOME"
+```
+
+**Verify generated files:**
+
+```bash
+ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
+ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).length)")
+
+for i in $(seq 0 $((ROW_COUNT - 1))); do
+  for f in "autoresearch/evaluate-row-${i}.js" "program-row-${i}.md" "loop-row-${i}.sh"; do
+    if [[ ! -f "$PROJECT_ROOT/$f" ]]; then
+      echo "ERROR: Missing $f"
+      exit 1
+    fi
+  done
+done
+
+# Reconciliation files
+for f in autoresearch/evaluate.js program.md loop.sh; do
+  if [[ ! -f "$PROJECT_ROOT/$f" ]]; then
+    echo "ERROR: Missing reconciliation file $f"
+    exit 1
+  fi
+done
+chmod +x "$PROJECT_ROOT"/loop-row-*.sh "$PROJECT_ROOT/loop.sh"
+echo "Polish loop infrastructure ready."
+```
+
+#### 5.2 Dev Server + Parallel Row Polish
+
+**Start dev server:**
+
+```bash
+cd "$PROJECT_ROOT" && aem up --html-folder . &
+AEM_PID=$!
+echo "AEM dev server starting (PID: $AEM_PID)..."
+```
+
+**Wait for server readiness** (poll until 200 response, max 30 seconds):
+
+```bash
+TRIES=0
+until curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/ | grep -q "200"; do
+  TRIES=$((TRIES + 1))
+  if [[ $TRIES -ge 30 ]]; then
+    echo "ERROR: AEM dev server did not start within 30 seconds."
+    kill $AEM_PID 2>/dev/null
+    exit 1
+  fi
+  sleep 1
+done
+echo "AEM dev server ready on http://localhost:3000/"
+```
+
+**Dispatch parallel row agents** — read `rows.json` and launch one Agent per row in a single message. Each agent runs its row's loop script.
+
+For each row (index `I`, description from `rows.json`), dispatch:
+
+```
+Agent({
+  description: "Polish row I (description)",
+  prompt: "Run the visual polish loop for row I of a header migration.\n\nExecute this command and wait for it to complete:\n\n```bash\ncd $PROJECT_ROOT && ./loop-row-I.sh 2>&1 | tee autoresearch/results/row-I/loop.log\n```\n\nThe loop runs autonomously — do not interfere with iterations.\nIt terminates on plateau (5 consecutive reverts) or max iterations.\nDo NOT wrap with timeout. Each iteration takes 8-12 minutes.\nWhen the loop finishes, report the final line of output.",
+  allowedTools: "Bash,Read"
+})
+```
+
+**All row agents MUST be dispatched in a single message** so they run in parallel.
+
+Wait for all agents to complete. Each row converges independently.
+
+Do NOT attempt to control individual iterations. The loops handle
+scoring, commit/revert decisions, and termination.
+
+Do NOT wrap the loops with `timeout` or any time limit. Each iteration
+takes 8-12 minutes. This is expected — let them run to completion.
+
+#### 5.3 Adaptive Reconciliation
+
+After all row loops finish, evaluate the full header to decide if reconciliation is needed.
+
+**Run full-header evaluation:**
+
+```bash
+RECON_SCORE=$(node "$PROJECT_ROOT/autoresearch/evaluate.js" 3000 recon 2>/dev/null \
+  | node --input-type=commonjs -e "
+    const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    const pm = d.viewports?.desktop?.similarity || 0;
+    const nav = d.navCompleteness?.score || 0;
+    console.log(Math.round((pm * 0.70 + nav * 0.30) * 100) / 100);
+  " 2>/dev/null || echo "0")
+echo "Full header score after row loops: ${RECON_SCORE}%"
+```
+
+**Decision gate:**
+
+```bash
+NEEDS_RECON=$(node -e "console.log(${RECON_SCORE} < 85 ? 'yes' : 'no')")
+if [[ "${NEEDS_RECON}" == "yes" ]]; then
+  echo "Score ${RECON_SCORE}% < 85% — running reconciliation loop..."
+  cd "$PROJECT_ROOT" && ./loop.sh 2>&1 | tee autoresearch/results/reconciliation.log
+  echo "Reconciliation finished."
+else
+  echo "Score ${RECON_SCORE}% >= 85% — rows converged cleanly, skipping reconciliation."
+fi
+```
+
+Mark Phase 5 as completed. Then proceed to Phase 6 — do NOT stop here.
+```
+
+- [ ] **Step 2: Verify no broken markdown or placeholder references**
+
+Read the modified SKILL.md and check that Phase 5 connects cleanly to Phase 4 (ends at line 822) and Phase 6 (starts at line 903).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/migrate-header/SKILL.md
+git commit -m "feat(migrate-header): rewrite Phase 5 for per-row parallel polish loops"
+```
+
+---
+
+### Task 7: Integration Smoke Test
+
+**Files:**
+- None created — manual verification
+
+Run the full test suite and verify the setup script works end-to-end with both modes.
+
+- [ ] **Step 1: Run all existing tests**
+
+```bash
+npx vitest run tests/migrate-header/
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 2: Verify template placeholder consistency**
+
+Check that every `{{PLACEHOLDER}}` in the three new templates has a matching key in `buildRowReplacements`:
+
+```bash
+grep -oE '\{\{[A-Z_]+\}\}' skills/migrate-header/templates/evaluate-row.js.tmpl \
+  skills/migrate-header/templates/loop-row.sh.tmpl \
+  skills/migrate-header/templates/program-row.md.tmpl \
+  | sort -u
+```
+
+Cross-reference each against `buildRowReplacements` keys. Any missing = bug.
+
+- [ ] **Step 3: Verify SKILL.md Phase 5 references correct file names**
+
+Check that SKILL.md references `loop-row-I.sh`, `program-row-I.md`, `evaluate-row-I.js`, `results-row-I.tsv` consistently.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(migrate-header): integration fixes for per-row polish loops"
+```
+
+(Skip if no fixes needed.)

--- a/docs/superpowers/specs/2026-04-09-per-row-polish-loops-design.md
+++ b/docs/superpowers/specs/2026-04-09-per-row-polish-loops-design.md
@@ -1,0 +1,191 @@
+# Per-Row Visual Polish Loops
+
+Optimize the migrate-header visual polish loop by spawning one loop per header row, converging in parallel, then running adaptive reconciliation on the full header.
+
+## Motivation
+
+The current polish loop iterates on the entire header as one unit. This causes two problems:
+
+1. **Cross-row interference** -- fixing one row's CSS regresses another row, wasting iterations on oscillation.
+2. **Speed** -- serial iteration on the full header is slow. Parallel per-row loops cut wall-clock time proportionally.
+
+Row isolation eliminates interference. Parallel dispatch reduces total time. Adaptive reconciliation catches any cross-row issues cheaply.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Per-row CSS files | `row-N.css` composed via `@import` in `header.css` | Agents must not edit the same file concurrently |
+| CSS isolation | Section-metadata classes (already exist) | No new mechanism needed |
+| Per-row scoring | pixelmatch 50% + judge 50% | Nav completeness is a whole-header concern |
+| Screenshots | Element screenshot per row DOM node | Cleaner than crop-from-full-page, no coordinate drift |
+| Parallel execution | Agent tool (one per row) | Matches Phase 3 extraction pattern |
+| Reconciliation | Adaptive: evaluate full header; if >= 85%, skip; else short loop (5 iterations) | Avoids wasting iterations when rows converge cleanly |
+| Git ratchet | File-scoped add/checkout per row (no reset --hard) | Prevents parallel agents from corrupting each other |
+
+## File Layout
+
+```
+loop-row-0.sh
+loop-row-1.sh
+program-row-0.md
+program-row-1.md
+autoresearch/
+  evaluate-row-0.js
+  evaluate-row-1.js
+  source/
+    desktop.png                    # full header (for reconciliation)
+    desktop-row-0.png              # cropped source for row 0
+    desktop-row-1.png              # cropped source for row 1
+    nav-structure.json             # for reconciliation only
+  results/
+    row-0/                         # row 0 screenshots, scores, judge history
+    row-1/                         # row 1 screenshots, scores, judge history
+blocks/header/
+  header.css                       # @import row-0.css; @import row-1.css;
+  row-0.css                        # owned by row-0 agent
+  row-1.css                        # owned by row-1 agent
+```
+
+## setup-polish-loop.js Changes
+
+### New flag: `--row=N`
+
+When present, generates infrastructure for one row only. When absent, generates full-header infrastructure (backward compatible, used for reconciliation).
+
+### Per-row mode (`--row=0`)
+
+- Reads only `row-0.json` from `--rows-dir`
+- Generates `loop-row-0.sh`, `program-row-0.md`, `evaluate-row-0.js`
+- Evaluator uses element screenshot of the row's CSS selector
+- Scoring: pixelmatch 50% + judge 50% (no nav completeness)
+- Source screenshot: crops `desktop.png` using row bounds at setup time, writes `source/desktop-row-0.png`
+- Results directory: `results/row-0/`
+- `program-row-0.md` scopes the agent to `row-0.css` only
+
+### Init mode (`--init-css`)
+
+A separate flag, run once before any `--row=N` calls:
+
+```bash
+node setup-polish-loop.js --init-css --rows-dir=... --target-dir=...
+```
+
+- Reads `rows.json` to determine row count
+- Creates empty `row-N.css` stub files in `blocks/header/`
+- Writes `header.css` with `@import url('row-N.css')` rules
+- Preserves any existing non-row content in `header.css` (global resets, shared vars)
+
+### Reconciliation mode (no `--row`, no `--init-css`)
+
+Generates full-header infrastructure (`loop.sh`, `program.md`, `evaluate.js`) exactly as today. Used for the optional reconciliation pass in Phase 5.3. Generated during 5.1 alongside per-row files.
+
+### New templates
+
+| Template | Based on | Key differences |
+|----------|----------|-----------------|
+| `evaluate-row.js.tmpl` | `evaluate.js.tmpl` | Element screenshot by selector, no nav completeness, results in `row-N/` subdir |
+| `loop-row.sh.tmpl` | `loop.sh.tmpl` | `HEADER_FILES=blocks/header/row-N.css`, file-scoped git ratchet, `row-N-` prefixed sessions, results file at `results-row-N.tsv` |
+| `program-row.md.tmpl` | `program.md.tmpl` | Scoped to one row, references `row-N.css`, row-specific description and visual tree |
+
+Judge templates (`judge.md.tmpl`, `judge-first.md.tmpl`) are unchanged -- they work with any source vs rendered screenshot pair.
+
+## SKILL.md Phase 5 Rewrite
+
+### 5.1 -- Polish Loop Setup (per-row)
+
+1. Generate `header.css` with `@import` rules and empty `row-N.css` stubs:
+   ```bash
+   node setup-polish-loop.js --init-css --rows-dir=... --target-dir=...
+   ```
+2. For each row in `rows.json`, generate per-row loop infrastructure:
+   ```bash
+   node setup-polish-loop.js --row=N --rows-dir=... --url=... --source-dir=... --target-dir=... --port=3000 --max-iterations=30 --skill-home=...
+   ```
+3. Generate full-header infrastructure for reconciliation (no `--row` flag):
+   ```bash
+   node setup-polish-loop.js --rows-dir=... --url=... --source-dir=... --target-dir=... --port=3000 --max-iterations=5 --skill-home=...
+   ```
+4. Verify generated files exist: `loop-row-N.sh`, `program-row-N.md`, `evaluate-row-N.js` for each row, plus `loop.sh`, `evaluate.js` for reconciliation.
+
+### 5.2 -- Parallel Row Polish
+
+Start AEM dev server once (shared). Dispatch one Agent per row in a single message:
+
+```
+Agent({ description: "Polish row 0", prompt: "cd $PROJECT_ROOT && ./loop-row-0.sh ..." })
+Agent({ description: "Polish row 1", prompt: "cd $PROJECT_ROOT && ./loop-row-1.sh ..." })
+```
+
+Wait for all agents to complete. Each converges independently via plateau detection or max iterations.
+
+Session naming: each row uses `row-N-eval` for evaluator, `row-N-judge` for judge. No collisions.
+
+### 5.3 -- Adaptive Reconciliation
+
+1. Run full-header evaluator once (existing `evaluate.js` -- screenshots entire `<header>`, pixelmatch vs `source/desktop.png`, checks nav completeness).
+2. If composite score >= 85%: skip reconciliation, log "rows converged cleanly."
+3. If composite score < 85%: run existing full-header polish loop with `--max-iterations=5`.
+
+The 85% threshold is a starting point. Tune after 3-5 real migrations.
+
+## Git Ratchet Isolation
+
+### Per-row loops
+
+Each `loop-row-N.sh` scopes git operations to its own file:
+
+- **Stage:** `git add blocks/header/row-N.css`
+- **Revert:** `git checkout -- blocks/header/row-N.css` (file-scoped, not `reset --hard`)
+- **Commit messages:** `row-0-iteration-3: ...` prefix to avoid log conflicts
+
+File-scoped operations prevent parallel agents from corrupting each other's work.
+
+### Reconciliation loop
+
+Uses the original `reset --hard` approach -- runs alone after all row loops complete, no concurrency concern.
+
+## Evaluator Changes (evaluate-row.js.tmpl)
+
+### Element screenshot
+
+```javascript
+cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${renderedPath}`);
+```
+
+Fallback: if `playwright-cli screenshot --selector=` is not supported, use full-page screenshot + crop from row bounds (detected at setup time).
+
+### No nav completeness
+
+`checkNavCompleteness()` is removed from per-row evaluator. Nav completeness is checked only during reconciliation by the full-header evaluator.
+
+### Scoring
+
+Per-row evaluator outputs pixelmatch similarity only. `loop-row-N.sh` computes: `pixel * 0.50 + judge * 0.50`.
+
+## Scope
+
+### In scope
+
+- `setup-polish-loop.js` gains `--row` flag
+- Three new templates: `evaluate-row.js.tmpl`, `loop-row.sh.tmpl`, `program-row.md.tmpl`
+- `header.css` rewritten to use `@import` rules
+- SKILL.md Phase 5 rewritten (5.1/5.2/5.3)
+- File-scoped git ratchet per row
+- Adaptive reconciliation with 85% threshold
+
+### Not in scope
+
+- Judge template changes
+- Phase 1-4 changes
+- Phase 6 changes
+- Mobile/responsive viewports
+- Per-row `nav.plain.html` (stays whole-header)
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Parallel playwright-cli sessions cause flaky screenshots on shared dev server | Each evaluator retries once on empty/corrupt screenshots |
+| 85% threshold is wrong (too high: skips needed reconciliation; too low: always runs it) | Tune after 3-5 real migrations |
+| `@import` adds extra HTTP requests in dev | Acceptable for dev-only migration tool |

--- a/skills/migrate-header/SKILL.md
+++ b/skills/migrate-header/SKILL.md
@@ -826,7 +826,35 @@ Mark Phase 5 as in_progress.
 
 #### 5.1 Polish Loop Setup
 
-Run the setup script to generate the polish loop infrastructure:
+**Initialize per-row CSS structure:**
+
+```bash
+node "$SKILL_HOME/scripts/setup-polish-loop.js" \
+  "--init-css" \
+  "--rows-dir=$PROJECT_ROOT/autoresearch/extraction" \
+  "--target-dir=$PROJECT_ROOT"
+```
+
+**Generate per-row loop infrastructure** — run once for each row in `rows.json`:
+
+```bash
+ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
+ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).length)")
+
+for i in $(seq 0 $((ROW_COUNT - 1))); do
+  node "$SKILL_HOME/scripts/setup-polish-loop.js" \
+    "--row=$i" \
+    "--rows-dir=$PROJECT_ROOT/autoresearch/extraction" \
+    "--url=$URL" \
+    "--source-dir=$PROJECT_ROOT/autoresearch/source" \
+    "--target-dir=$PROJECT_ROOT" \
+    "--port=3000" \
+    "--max-iterations=$MAX_ITERATIONS" \
+    "--skill-home=$SKILL_HOME"
+done
+```
+
+**Generate full-header infrastructure for reconciliation:**
 
 ```bash
 node "$SKILL_HOME/scripts/setup-polish-loop.js" \
@@ -835,26 +863,37 @@ node "$SKILL_HOME/scripts/setup-polish-loop.js" \
   "--source-dir=$PROJECT_ROOT/autoresearch/source" \
   "--target-dir=$PROJECT_ROOT" \
   "--port=3000" \
-  "--max-iterations=$MAX_ITERATIONS" \
+  "--max-iterations=5" \
   "--skill-home=$SKILL_HOME"
 ```
 
-Verify the generated files exist:
+**Verify generated files:**
 
 ```bash
+ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
+ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).length)")
+
+for i in $(seq 0 $((ROW_COUNT - 1))); do
+  for f in "autoresearch/evaluate-row-${i}.js" "program-row-${i}.md" "loop-row-${i}.sh"; do
+    if [[ ! -f "$PROJECT_ROOT/$f" ]]; then
+      echo "ERROR: Missing $f"
+      exit 1
+    fi
+  done
+done
+
+# Reconciliation files
 for f in autoresearch/evaluate.js program.md loop.sh; do
   if [[ ! -f "$PROJECT_ROOT/$f" ]]; then
-    echo "ERROR: Polish loop setup failed -- missing $f"
+    echo "ERROR: Missing reconciliation file $f"
     exit 1
   fi
 done
-chmod +x "$PROJECT_ROOT/loop.sh"
+chmod +x "$PROJECT_ROOT"/loop-row-*.sh "$PROJECT_ROOT/loop.sh"
 echo "Polish loop infrastructure ready."
 ```
 
-#### 5.2 Dev Server + Polish Loop
-
-Start the AEM dev server in the background, then launch the polish loop.
+#### 5.2 Dev Server + Parallel Row Polish
 
 **Start dev server:**
 
@@ -880,23 +919,57 @@ done
 echo "AEM dev server ready on http://localhost:3000/"
 ```
 
-**Launch the polish loop** (this blocks until completion):
+**Dispatch parallel row agents** — read `rows.json` and launch one Agent per row in a single message. Each agent runs its row's loop script.
 
-```bash
-cd "$PROJECT_ROOT" && ./loop.sh 2>&1 | tee autoresearch/results/loop.log
-echo "Loop finished. Full log at autoresearch/results/loop.log"
+For each row (index `I`, description from `rows.json`), dispatch:
+
+```
+Agent({
+  description: "Polish row I (description)",
+  prompt: "Run the visual polish loop for row I of a header migration.\n\nExecute this command and wait for it to complete:\n\n```bash\ncd $PROJECT_ROOT && ./loop-row-I.sh 2>&1 | tee autoresearch/results/row-I/loop.log\n```\n\nThe loop runs autonomously — do not interfere with iterations.\nIt terminates on plateau (5 consecutive reverts) or max iterations.\nDo NOT wrap with timeout. Each iteration takes 8-12 minutes.\nWhen the loop finishes, report the final line of output.",
+  allowedTools: "Bash,Read"
+})
 ```
 
-The loop runs autonomously. It terminates on:
-- 5 consecutive reverted iterations (plateau)
-- Reaching `--max-iterations`
+**All row agents MUST be dispatched in a single message** so they run in parallel.
 
-Do NOT attempt to control individual iterations. The loop handles
+Wait for all agents to complete. Each row converges independently.
+
+Do NOT attempt to control individual iterations. The loops handle
 scoring, commit/revert decisions, and termination.
 
-Do NOT wrap the loop with `timeout` or any time limit. Each iteration
-takes 8-12 minutes, so 10 iterations needs ~90+ minutes. This is
-expected — let it run to completion.
+Do NOT wrap the loops with `timeout` or any time limit. Each iteration
+takes 8-12 minutes. This is expected — let them run to completion.
+
+#### 5.3 Adaptive Reconciliation
+
+After all row loops finish, evaluate the full header to decide if reconciliation is needed.
+
+**Run full-header evaluation:**
+
+```bash
+RECON_SCORE=$(node "$PROJECT_ROOT/autoresearch/evaluate.js" 3000 recon 2>/dev/null \
+  | node --input-type=commonjs -e "
+    const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    const pm = d.viewports?.desktop?.similarity || 0;
+    const nav = d.navCompleteness?.score || 0;
+    console.log(Math.round((pm * 0.70 + nav * 0.30) * 100) / 100);
+  " 2>/dev/null || echo "0")
+echo "Full header score after row loops: ${RECON_SCORE}%"
+```
+
+**Decision gate:**
+
+```bash
+NEEDS_RECON=$(node -e "console.log(${RECON_SCORE} < 85 ? 'yes' : 'no')")
+if [[ "${NEEDS_RECON}" == "yes" ]]; then
+  echo "Score ${RECON_SCORE}% < 85% — running reconciliation loop..."
+  cd "$PROJECT_ROOT" && ./loop.sh 2>&1 | tee autoresearch/results/reconciliation.log
+  echo "Reconciliation finished."
+else
+  echo "Score ${RECON_SCORE}% >= 85% — rows converged cleanly, skipping reconciliation."
+fi
+```
 
 Mark Phase 5 as completed. Then proceed to Phase 6 — do NOT stop here.
 

--- a/skills/migrate-header/SKILL.md
+++ b/skills/migrate-header/SKILL.md
@@ -525,6 +525,41 @@ Mark Phase 2 as completed.
 
 Mark Phase 3 as in_progress.
 
+#### 3.0 Pre-Extract Row Content
+
+Before dispatching row agents, extract complete DOM content for each row
+deterministically. This prevents LLM truncation of large dropdown menus.
+
+The visual-tree session from Phase 2 is still open. For each row in
+`rows.json`, run the extraction script:
+
+```bash
+ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
+ROW_COUNT=$(node -e "
+  const rows = JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8'));
+  console.log(rows.rows.length);
+")
+EXTRACT_DIR="$PROJECT_ROOT/autoresearch/extraction/content"
+mkdir -p "$EXTRACT_DIR"
+
+for i in $(seq 0 $((ROW_COUNT - 1))); do
+  ROW_SELECTOR=$(node -e "
+    const rows = JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8'));
+    console.log(rows.rows[$i].selector);
+  ")
+  node "$SKILL_HOME/scripts/extract-row-content.js" \
+    "$VT_SESSION" \
+    "$ROW_SELECTOR" \
+    "$EXTRACT_DIR/row-${i}-content.json"
+done
+echo "Pre-extracted content for $ROW_COUNT rows"
+```
+
+Each `row-N-content.json` contains a complete array of elements with:
+- `cleanHtml` — full cleaned innerHTML (no truncation, no size limit)
+- `links` — structured link array with text, href, images
+- `topText`, `topHref` — top-level element text and link
+
 #### 3.1 Row Agent Dispatch
 
 Read `$PROJECT_ROOT/autoresearch/source/rows.json` (produced in step 2.4).
@@ -578,39 +613,32 @@ playwright-cli -s=row-[INDEX] eval "<expression>"
    node [CSS_QUERY_PATH] open [URL] --session=row-[INDEX] [BROWSER_RECIPE_FLAG]
    ```
 
-2. Read the row's DOM content:
+2. Read the pre-extracted row content (complete DOM, no truncation):
    ```bash
-   playwright-cli -s=row-[INDEX] eval "document.querySelector('[SELECTOR]').innerHTML"
+   cat [PROJECT_ROOT]/autoresearch/extraction/content/row-[INDEX]-content.json
    ```
+   This JSON array has one entry per direct child element of the row, each with:
+   - `cleanHtml` — full cleaned innerHTML
+   - `links` — structured array of all links (including hidden dropdown children)
+   - `topText`, `topHref` — top-level text and link
 
-3. Analyze the DOM to classify elements. Assign each a role:
+3. Classify each element from the pre-extracted content. Assign each a role:
    logo, nav-link, utility-link, promotional-card, search, icon, cta, text.
-   For nav-link elements, also extract children from nested <ul>s —
-   including items in hidden submenus (display:none panels). These are
-   real navigation links that belong in the output.
+   For nav-link elements, the `links` array contains ALL children from nested
+   `<ul>`s — including items in hidden submenus (display:none panels). These
+   are real navigation links that belong in the output.
 
-3b. For each element, capture its cleaned innerHTML:
-    ```bash
-    playwright-cli -s=row-[INDEX] eval "
-      const el = document.querySelector('<element-selector>').cloneNode(true);
-      el.querySelectorAll('script,style,noscript').forEach(n => n.remove());
-      el.innerHTML.trim()
-    "
-    ```
-    Store the output as the element's `contentHtml` field.
+3b. Use the `cleanHtml` field from the pre-extracted content as the element's
+    `contentHtml` field in your output. Do NOT re-extract innerHTML via eval —
+    the pre-extracted content is complete and avoids truncation of large
+    dropdown menus.
 
-    **For nav-link elements with dropdowns:** use the nav item's own
-    `<li>` as the selector — NOT a child container like a link list.
-    Dropdown panels often have sibling `<div>`s next to the link list
-    containing promotional cards, featured images, and CTAs. Selecting
-    only the link list `<ul>` misses these siblings. The `<li>` is the
-    common ancestor that contains everything:
+    **For nav-link elements with dropdowns:** the `cleanHtml` captures the
+    entire `<li>` content — NOT just a child container like a link list.
+    This includes:
     - The main link
     - The nested `<ul>` of submenu links
     - Spotlight/promotional `<div>`s with images
-
-    Example: if the nav item is `li.menu-item:nth-child(3)`, query
-    that `<li>` directly — do not drill into its children.
 
 4. Query CSS values for each element type via css-query:
    ```bash

--- a/skills/migrate-header/SKILL.md
+++ b/skills/migrate-header/SKILL.md
@@ -839,7 +839,7 @@ node "$SKILL_HOME/scripts/setup-polish-loop.js" \
 
 ```bash
 ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
-ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).length)")
+ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).rows.length)")
 
 for i in $(seq 0 $((ROW_COUNT - 1))); do
   node "$SKILL_HOME/scripts/setup-polish-loop.js" \
@@ -871,7 +871,7 @@ node "$SKILL_HOME/scripts/setup-polish-loop.js" \
 
 ```bash
 ROWS_JSON="$PROJECT_ROOT/autoresearch/source/rows.json"
-ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).length)")
+ROW_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROWS_JSON','utf-8')).rows.length)")
 
 for i in $(seq 0 $((ROW_COUNT - 1))); do
   for f in "autoresearch/evaluate-row-${i}.js" "program-row-${i}.md" "loop-row-${i}.sh"; do
@@ -991,10 +991,15 @@ if [[ -n "$AEM_PID" ]]; then
 fi
 ```
 
-**Read results** from `$PROJECT_ROOT/results.tsv`
-and `$PROJECT_ROOT/autoresearch/results/latest-evaluation.json`.
+**Read results** from `$PROJECT_ROOT/autoresearch/results/latest-evaluation.json`
+(always present — written by Phase 5.3 full-header evaluation).
+
+For iteration details, read per-row results:
+- `$PROJECT_ROOT/results-row-0.tsv`, `results-row-1.tsv`, etc. (one per row)
+- `$PROJECT_ROOT/results.tsv` (only exists if reconciliation ran)
+
 Extract: composite score, desktop score, nav completeness,
-iteration count (kept vs reverted).
+iteration count (kept vs reverted) across all row TSVs.
 
 **Report to user** with this format:
 

--- a/skills/migrate-header/scripts/capture-visual-tree.js
+++ b/skills/migrate-header/scripts/capture-visual-tree.js
@@ -109,10 +109,11 @@ export function buildConfig(bundlePath, browserRecipePath) {
     Object.assign(config.browser, cliConf.browser || {});
   }
 
-  config.browser.initScript = [
-    ...(config.browser.initScript || []),
-    bundlePath,
-  ];
+  const existing = config.browser.initScript;
+  const scripts = Array.isArray(existing)
+    ? existing
+    : existing ? [existing] : [];
+  config.browser.initScript = [...scripts, bundlePath];
 
   return config;
 }

--- a/skills/migrate-header/scripts/capture-visual-tree.js
+++ b/skills/migrate-header/scripts/capture-visual-tree.js
@@ -102,20 +102,33 @@ function cli(session, ...args) {
 
 export function buildConfig(bundlePath, browserRecipePath) {
   const config = { browser: {} };
+  let stealthTmpFile = null;
 
   if (browserRecipePath && existsSync(browserRecipePath)) {
     const recipe = JSON.parse(readFileSync(browserRecipePath, 'utf-8'));
     const cliConf = recipe.cliConfig || {};
     Object.assign(config.browser, cliConf.browser || {});
+
+    // Write stealth script to temp file if present in recipe
+    if (recipe.stealthInitScript) {
+      stealthTmpFile = join(
+        tmpdir(), `vt-stealth-${process.pid}.js`,
+      );
+      writeFileSync(stealthTmpFile, recipe.stealthInitScript);
+    }
   }
 
   const existing = config.browser.initScript;
   const scripts = Array.isArray(existing)
     ? existing
     : existing ? [existing] : [];
-  config.browser.initScript = [...scripts, bundlePath];
 
-  return config;
+  // Stealth first (must run before page scripts), then bundle last
+  if (stealthTmpFile) scripts.unshift(stealthTmpFile);
+  scripts.push(bundlePath);
+  config.browser.initScript = scripts;
+
+  return { config, stealthTmpFile };
 }
 
 function main() {
@@ -132,7 +145,7 @@ function main() {
 
   const configPath = join(tmpdir(), `vt-config-${process.pid}.json`);
   const rawPath = join(tmpdir(), `vt-raw-${process.pid}.txt`);
-  const config = buildConfig(bundle, args.browserRecipe);
+  const { config, stealthTmpFile } = buildConfig(bundle, args.browserRecipe);
   writeFileSync(configPath, JSON.stringify(config, null, 2));
 
   try {
@@ -180,7 +193,7 @@ function main() {
     log(`ERROR: Visual tree capture failed: ${err.message}`);
     process.exit(2);
   } finally {
-    for (const f of [configPath, rawPath]) {
+    for (const f of [configPath, rawPath, stealthTmpFile].filter(Boolean)) {
       try { unlinkSync(f); } catch { /* noop */ }
     }
   }

--- a/skills/migrate-header/scripts/extract-row-content.js
+++ b/skills/migrate-header/scripts/extract-row-content.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Deterministic row content extraction via playwright-cli --raw run-code.
+ * Deterministic row content extraction via playwright-cli run-code --filename.
  *
  * Extracts complete DOM content for each direct child of a header row,
  * bypassing LLM truncation. Produces a JSON file per row with cleaned
@@ -15,7 +15,9 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const EXEC_OPTS = {
   encoding: 'utf-8',
@@ -36,25 +38,25 @@ const outputPath = process.argv[4];
 
 if (!session || !rowSelector || !outputPath) usage();
 
-// The extraction code runs inside page.evaluate — no Node APIs, pure browser JS.
-// We pass rowSelector as a parameter to avoid shell quoting issues.
-const extractCode = `async page => {
+// Write extraction code to a temp file — avoids shell quoting issues
+// with complex selectors and large inline strings.
+const scriptPath = join(tmpdir(), `extract-row-${process.pid}.js`);
+
+writeFileSync(scriptPath, `
+async page => {
   return await page.evaluate((rowSel) => {
     const row = document.querySelector(rowSel);
     if (!row) return JSON.stringify({ error: 'Row not found: ' + rowSel });
 
-    // Find direct children that are actual content elements
     const children = Array.from(row.children).filter(el => {
       const tag = el.tagName.toLowerCase();
       return tag !== 'script' && tag !== 'style' && tag !== 'noscript';
     });
 
     return JSON.stringify(children.map((child, i) => {
-      // Clone to avoid mutating the page
       const clone = child.cloneNode(true);
       clone.querySelectorAll('script,style,noscript').forEach(n => n.remove());
 
-      // Extract all links (including hidden dropdown content)
       const links = Array.from(child.querySelectorAll('a[href]')).map(a => ({
         text: a.textContent.replace(/\\s+/g, ' ').trim(),
         href: a.getAttribute('href'),
@@ -63,7 +65,6 @@ const extractCode = `async page => {
         imgAlt: a.querySelector('img')?.getAttribute('alt') || null,
       })).filter(l => l.text.length > 0 || l.hasImage);
 
-      // Top-level link or text
       const topLink = child.querySelector(':scope > a');
       const topText = topLink
         ? topLink.textContent.replace(/\\s+/g, ' ').trim()
@@ -79,18 +80,16 @@ const extractCode = `async page => {
         cleanHtml: clone.innerHTML.replace(/\\s+/g, ' ').trim(),
       };
     }));
-  }, '${rowSelector.replace(/'/g, "\\'")}');
-}`;
+  }, ${JSON.stringify(rowSelector)});
+}
+`);
 
 try {
   const raw = execFileSync('playwright-cli', [
-    `-s=${session}`, '--raw', 'run-code', extractCode,
+    `-s=${session}`, '--raw', 'run-code', `--filename=${scriptPath}`,
   ], EXEC_OPTS);
 
-  // run-code with --raw returns the value directly (string-encoded JSON)
   const parsed = JSON.parse(raw);
-
-  // parsed is either the JSON string from page.evaluate or an error object
   const items = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
 
   if (items.error) {
@@ -107,4 +106,6 @@ try {
 } catch (err) {
   console.error(`extract-row-content failed: ${err.message}`);
   process.exit(1);
+} finally {
+  try { unlinkSync(scriptPath); } catch { /* noop */ }
 }

--- a/skills/migrate-header/scripts/extract-row-content.js
+++ b/skills/migrate-header/scripts/extract-row-content.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * Deterministic row content extraction via playwright-cli --raw run-code.
+ *
+ * Extracts complete DOM content for each direct child of a header row,
+ * bypassing LLM truncation. Produces a JSON file per row with cleaned
+ * innerHTML and structured link trees for every element.
+ *
+ * Usage:
+ *   node extract-row-content.js <session> <row-selector> <output-path>
+ *
+ * Requires an open playwright-cli session on the target page.
+ * Output: JSON array of extracted elements written to <output-path>.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const EXEC_OPTS = {
+  encoding: 'utf-8',
+  maxBuffer: 10 * 1024 * 1024,
+  timeout: 30000,
+};
+
+function usage() {
+  console.error(
+    'Usage: node extract-row-content.js <session> <row-selector> <output-path>',
+  );
+  process.exit(1);
+}
+
+const session = process.argv[2];
+const rowSelector = process.argv[3];
+const outputPath = process.argv[4];
+
+if (!session || !rowSelector || !outputPath) usage();
+
+// The extraction code runs inside page.evaluate — no Node APIs, pure browser JS.
+// We pass rowSelector as a parameter to avoid shell quoting issues.
+const extractCode = `async page => {
+  return await page.evaluate((rowSel) => {
+    const row = document.querySelector(rowSel);
+    if (!row) return JSON.stringify({ error: 'Row not found: ' + rowSel });
+
+    // Find direct children that are actual content elements
+    const children = Array.from(row.children).filter(el => {
+      const tag = el.tagName.toLowerCase();
+      return tag !== 'script' && tag !== 'style' && tag !== 'noscript';
+    });
+
+    return JSON.stringify(children.map((child, i) => {
+      // Clone to avoid mutating the page
+      const clone = child.cloneNode(true);
+      clone.querySelectorAll('script,style,noscript').forEach(n => n.remove());
+
+      // Extract all links (including hidden dropdown content)
+      const links = Array.from(child.querySelectorAll('a[href]')).map(a => ({
+        text: a.textContent.replace(/\\s+/g, ' ').trim(),
+        href: a.getAttribute('href'),
+        hasImage: !!a.querySelector('img'),
+        imgSrc: a.querySelector('img')?.getAttribute('src') || null,
+        imgAlt: a.querySelector('img')?.getAttribute('alt') || null,
+      })).filter(l => l.text.length > 0 || l.hasImage);
+
+      // Top-level link or text
+      const topLink = child.querySelector(':scope > a');
+      const topText = topLink
+        ? topLink.textContent.replace(/\\s+/g, ' ').trim()
+        : child.textContent.replace(/\\s+/g, ' ').trim().slice(0, 200);
+
+      return {
+        index: i,
+        tag: child.tagName.toLowerCase(),
+        topText,
+        topHref: topLink?.getAttribute('href') || null,
+        linkCount: links.length,
+        links,
+        cleanHtml: clone.innerHTML.replace(/\\s+/g, ' ').trim(),
+      };
+    }));
+  }, '${rowSelector.replace(/'/g, "\\'")}');
+}`;
+
+try {
+  const raw = execFileSync('playwright-cli', [
+    `-s=${session}`, '--raw', 'run-code', extractCode,
+  ], EXEC_OPTS);
+
+  // run-code with --raw returns the value directly (string-encoded JSON)
+  const parsed = JSON.parse(raw);
+
+  // parsed is either the JSON string from page.evaluate or an error object
+  const items = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
+
+  if (items.error) {
+    console.error(`Extraction failed: ${items.error}`);
+    process.exit(1);
+  }
+
+  writeFileSync(outputPath, JSON.stringify(items, null, 2));
+
+  const totalLinks = items.reduce((s, it) => s + it.linkCount, 0);
+  console.error(
+    `Extracted ${items.length} elements (${totalLinks} links) → ${outputPath}`,
+  );
+} catch (err) {
+  console.error(`extract-row-content failed: ${err.message}`);
+  process.exit(1);
+}

--- a/skills/migrate-header/scripts/extract-row-content.js
+++ b/skills/migrate-header/scripts/extract-row-content.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Deterministic row content extraction via playwright-cli run-code --filename.
+ * Deterministic row content extraction via playwright-cli --raw run-code --filename.
  *
  * Extracts complete DOM content for each direct child of a header row,
  * bypassing LLM truncation. Produces a JSON file per row with cleaned
@@ -15,9 +15,8 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, unlinkSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 
 const EXEC_OPTS = {
   encoding: 'utf-8',
@@ -38,9 +37,11 @@ const outputPath = process.argv[4];
 
 if (!session || !rowSelector || !outputPath) usage();
 
-// Write extraction code to a temp file — avoids shell quoting issues
-// with complex selectors and large inline strings.
-const scriptPath = join(tmpdir(), `extract-row-${process.pid}.js`);
+// Write extraction code to .playwright-cli/ (inside the sandbox's allowed roots)
+// — avoids shell quoting issues with complex selectors and large inline strings.
+const pwDir = join(process.cwd(), '.playwright-cli');
+mkdirSync(pwDir, { recursive: true });
+const scriptPath = join(pwDir, `extract-row-${process.pid}.js`);
 
 writeFileSync(scriptPath, `
 async page => {

--- a/skills/migrate-header/scripts/setup-polish-loop.js
+++ b/skills/migrate-header/scripts/setup-polish-loop.js
@@ -28,9 +28,53 @@ const TEMPLATES_DIR = join(__dirname, '..', 'templates');
 
 function parseArgs(argv) {
   const named = {};
+  const booleans = new Set();
   for (const arg of argv.slice(2)) {
-    const m = arg.match(/^--([a-z-]+)=(.+)$/);
-    if (m) named[m[1]] = m[2];
+    const kvMatch = arg.match(/^--([a-z-]+)=(.+)$/);
+    if (kvMatch) {
+      named[kvMatch[1]] = kvMatch[2];
+      continue;
+    }
+    const boolMatch = arg.match(/^--([a-z-]+)$/);
+    if (boolMatch) booleans.add(boolMatch[1]);
+  }
+
+  if (booleans.has('init-css')) {
+    const required = ['rows-dir', 'target-dir'];
+    const missing = required.filter((k) => !named[k]);
+    if (missing.length > 0) {
+      console.error(
+        `Missing required arguments: ${missing.map((k) => `--${k}`).join(', ')}`,
+      );
+      process.exit(1);
+    }
+    return {
+      mode: 'init-css',
+      rowsDir: resolve(named['rows-dir']),
+      targetDir: resolve(named['target-dir']),
+    };
+  }
+
+  if (named['row'] != null) {
+    const required = ['rows-dir', 'url', 'source-dir', 'target-dir'];
+    const missing = required.filter((k) => !named[k]);
+    if (missing.length > 0) {
+      console.error(
+        `Missing required arguments: ${missing.map((k) => `--${k}`).join(', ')}`,
+      );
+      process.exit(1);
+    }
+    return {
+      mode: 'row',
+      rowIndex: parseInt(named['row'], 10),
+      rowsDir: resolve(named['rows-dir']),
+      url: named['url'],
+      sourceDir: resolve(named['source-dir']),
+      targetDir: resolve(named['target-dir']),
+      explicitPort: named['port'] || null,
+      maxIterations: named['max-iterations'] || '30',
+      skillHome: named['skill-home'] || join(__dirname, '..'),
+    };
   }
 
   const required = ['rows-dir', 'url', 'source-dir', 'target-dir'];
@@ -49,6 +93,7 @@ function parseArgs(argv) {
   }
 
   return {
+    mode: 'full',
     rowsDir: resolve(named['rows-dir']),
     url: named['url'],
     sourceDir: resolve(named['source-dir']),
@@ -192,6 +237,32 @@ export function synthesizeStyles(rows) {
   return styles;
 }
 
+export function generateInitCss(rows) {
+  return rows.map((_, i) => `@import url('row-${i}.css');`).join('\n') + '\n';
+}
+
+export function buildRowReplacements(row, opts) {
+  return {
+    '{{ROW_INDEX}}': String(row.index),
+    '{{ROW_SELECTOR}}': row.selector
+      || `header > :nth-child(${row.index + 1})`,
+    '{{ROW_SESSION}}': `row-${row.index}-eval`,
+    '{{ROW_HEIGHT}}': String(Math.round(row.bounds.height)),
+    '{{ROW_SECTION_STYLE}}': row.suggestedSectionStyle
+      || `row-${row.index}`,
+    '{{ROW_DESCRIPTION}}': row.description || `Row ${row.index}`,
+    '{{ROW_VISUAL_TREE}}': row.vtSubtree
+      || 'Visual tree not available.',
+    '{{PORT}}': opts.port,
+    '{{PAGE_PATH}}': '/',
+    '{{MAX_ITERATIONS}}': opts.maxIterations,
+    '{{MAX_CONSECUTIVE_REVERTS}}': '5',
+    '{{URL}}': opts.url,
+    '{{SKILL_HOME}}': opts.skillHome,
+    '{{ICON_GUIDANCE}}': opts.iconGuidance || '',
+  };
+}
+
 function buildIconGuidance(targetDir) {
   const manifestPath = join(
     targetDir, 'autoresearch', 'extraction', 'icons', 'icons.json'
@@ -257,10 +328,174 @@ function log(msg) {
   console.error(msg);
 }
 
-function main() {
-  const args = parseArgs(process.argv);
+function applyReplacements(template, replacements) {
+  let result = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    while (result.includes(key)) {
+      result = result.replace(key, value);
+    }
+  }
+  return result;
+}
 
-  // Load row extraction data
+function installEvaluatorDeps(autoresearchDir) {
+  log('Installing evaluator dependencies...');
+  execSync('npm init -y', { cwd: autoresearchDir, stdio: 'pipe' });
+  const pkgPath = join(autoresearchDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+  pkg.type = 'module';
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  execSync('npm install pixelmatch pngjs', {
+    cwd: autoresearchDir,
+    stdio: 'pipe',
+  });
+  log('  Installed pixelmatch + pngjs');
+}
+
+function ensureEvaluatorDeps(autoresearchDir) {
+  const pngjsDir = join(autoresearchDir, 'node_modules', 'pngjs');
+  if (existsSync(pngjsDir)) return;
+  installEvaluatorDeps(autoresearchDir);
+}
+
+function mainInitCss(args) {
+  const rows = loadRowFiles(args.rowsDir);
+  if (rows.length === 0) {
+    console.error(`No row-*.json files found in: ${args.rowsDir}`);
+    process.exit(1);
+  }
+  log(`Loaded ${rows.length} row files from ${args.rowsDir}`);
+
+  const headerDir = join(args.targetDir, 'blocks', 'header');
+  mkdirSync(headerDir, { recursive: true });
+
+  // Create empty row-N.css stubs
+  for (let i = 0; i < rows.length; ++i) {
+    const stubPath = join(headerDir, `row-${i}.css`);
+    if (!existsSync(stubPath)) {
+      writeFileSync(stubPath, '');
+      log(`  Created blocks/header/row-${i}.css`);
+    }
+  }
+
+  // Write header.css with @import rules, preserving non-import content
+  const headerCssPath = join(headerDir, 'header.css');
+  let existingNonImport = '';
+  if (existsSync(headerCssPath)) {
+    const existing = readFileSync(headerCssPath, 'utf-8');
+    existingNonImport = existing
+      .split('\n')
+      .filter((line) => !line.startsWith('@import'))
+      .join('\n')
+      .trim();
+  }
+  const importBlock = generateInitCss(rows);
+  const cssContent = existingNonImport
+    ? importBlock + '\n' + existingNonImport + '\n'
+    : importBlock;
+  writeFileSync(headerCssPath, cssContent);
+  log(`  Wrote blocks/header/header.css (${rows.length} @import rules)`);
+
+  // Install npm deps so --row mode can use pngjs for cropping
+  const autoresearchDir = join(args.targetDir, 'autoresearch');
+  mkdirSync(autoresearchDir, { recursive: true });
+  installEvaluatorDeps(autoresearchDir);
+
+  log('');
+  log('Init CSS complete.');
+  log(`  ${rows.length} row stubs + header.css created`);
+}
+
+async function mainRow(args) {
+  const rows = loadRowFiles(args.rowsDir);
+  const row = rows.find((r) => r.index === args.rowIndex);
+  if (!row) {
+    console.error(
+      `Row ${args.rowIndex} not found in ${args.rowsDir}`
+      + ` (available: ${rows.map((r) => r.index).join(', ')})`,
+    );
+    process.exit(1);
+  }
+  log(`Loaded row ${row.index} from ${args.rowsDir}`);
+
+  const autoresearchDir = join(args.targetDir, 'autoresearch');
+  const sourceOutDir = join(autoresearchDir, 'source');
+  mkdirSync(sourceOutDir, { recursive: true });
+
+  // Crop source screenshot for this row using pngjs
+  const desktopPath = join(sourceOutDir, 'desktop.png');
+  if (existsSync(desktopPath)) {
+    const pngjsPath = join(
+      autoresearchDir, 'node_modules', 'pngjs', 'lib', 'pngjs.js',
+    );
+    const { PNG } = await import(pngjsPath);
+    const srcData = readFileSync(desktopPath);
+    const srcPng = PNG.sync.read(srcData);
+
+    const cropY = Math.max(0, Math.round(row.bounds.y || 0));
+    const cropH = Math.min(
+      Math.round(row.bounds.height),
+      srcPng.height - cropY,
+    );
+    const cropped = new PNG({ width: srcPng.width, height: cropH });
+    PNG.bitblt(srcPng, cropped, 0, cropY, srcPng.width, cropH, 0, 0);
+
+    const cropPath = join(
+      sourceOutDir, `desktop-row-${row.index}.png`,
+    );
+    writeFileSync(cropPath, PNG.sync.write(cropped));
+    log(`  Cropped source/desktop-row-${row.index}.png (${cropH}px)`);
+  } else {
+    log('  WARNING: desktop.png not found, skipping crop');
+  }
+
+  const port = detectPort(args.targetDir, args.explicitPort);
+  const replacements = buildRowReplacements(row, {
+    port,
+    maxIterations: args.maxIterations,
+    url: args.url,
+    skillHome: args.skillHome,
+    iconGuidance: buildIconGuidance(args.targetDir),
+  });
+
+  // Load and populate per-row templates
+  const evaluateTmpl = loadTemplate('evaluate-row.js.tmpl');
+  const loopTmpl = loadTemplate('loop-row.sh.tmpl');
+  const programTmpl = loadTemplate('program-row.md.tmpl');
+
+  const evaluateContent = applyReplacements(evaluateTmpl, replacements);
+  const loopContent = applyReplacements(loopTmpl, replacements);
+  const programContent = applyReplacements(programTmpl, replacements);
+
+  // Write populated files
+  writeFileSync(
+    join(autoresearchDir, `evaluate-row-${row.index}.js`),
+    evaluateContent,
+  );
+  log(`  Wrote autoresearch/evaluate-row-${row.index}.js`);
+
+  const loopPath = join(args.targetDir, `loop-row-${row.index}.sh`);
+  writeFileSync(loopPath, loopContent);
+  chmodSync(loopPath, 0o755);
+  log(`  Wrote loop-row-${row.index}.sh (chmod +x)`);
+
+  writeFileSync(
+    join(args.targetDir, `program-row-${row.index}.md`),
+    programContent,
+  );
+  log(`  Wrote program-row-${row.index}.md`);
+
+  // Create per-row results directory
+  const rowResultsDir = join(autoresearchDir, 'results', `row-${row.index}`);
+  mkdirSync(rowResultsDir, { recursive: true });
+  log(`  Created autoresearch/results/row-${row.index}/`);
+
+  log('');
+  log(`Row ${row.index} polish loop infrastructure ready.`);
+  log(`  Run: cd ${args.targetDir} && ./loop-row-${row.index}.sh`);
+}
+
+function mainFull(args) {
   const rows = loadRowFiles(args.rowsDir);
   if (rows.length === 0) {
     console.error(`No row-*.json files found in: ${args.rowsDir}`);
@@ -313,20 +548,9 @@ function main() {
   const loopTmpl = loadTemplate('loop.sh.tmpl');
   const programTmpl = loadTemplate('program.md.tmpl');
 
-  // Apply replacements
-  function applyReplacements(template) {
-    let result = template;
-    for (const [key, value] of Object.entries(replacements)) {
-      while (result.includes(key)) {
-        result = result.replace(key, value);
-      }
-    }
-    return result;
-  }
-
-  const evaluateContent = applyReplacements(evaluateTmpl);
-  const loopContent = applyReplacements(loopTmpl);
-  const programContent = applyReplacements(programTmpl);
+  const evaluateContent = applyReplacements(evaluateTmpl, replacements);
+  const loopContent = applyReplacements(loopTmpl, replacements);
+  const programContent = applyReplacements(programTmpl, replacements);
 
   // Create directory structure
   const autoresearchDir = join(args.targetDir, 'autoresearch');
@@ -363,22 +587,8 @@ function main() {
   );
   log(`  Wrote source/nav-structure.json (${navStructure.topNav.length} items)`);
 
-  // Install npm dependencies for evaluator
-  log('Installing evaluator dependencies...');
-  execSync('npm init -y', {
-    cwd: autoresearchDir,
-    stdio: 'pipe',
-  });
-  const pkgPath = join(autoresearchDir, 'package.json');
-  const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-  pkg.type = 'module';
-  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
-
-  execSync('npm install pixelmatch pngjs', {
-    cwd: autoresearchDir,
-    stdio: 'pipe',
-  });
-  log('  Installed pixelmatch + pngjs');
+  // Ensure npm deps are installed (--init-css installs them; fallback here)
+  ensureEvaluatorDeps(autoresearchDir);
 
   log('');
   log('Polish loop infrastructure ready.');
@@ -388,8 +598,18 @@ function main() {
   log(`  Run: cd ${args.targetDir} && ./loop.sh`);
 }
 
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.mode === 'init-css') return mainInitCss(args);
+  if (args.mode === 'row') return mainRow(args);
+  return mainFull(args);
+}
+
 const isDirectRun = process.argv[1]
   && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectRun) {
-  main();
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/skills/migrate-header/scripts/setup-polish-loop.js
+++ b/skills/migrate-header/scripts/setup-polish-loop.js
@@ -22,6 +22,7 @@ import {
 import { dirname, join, resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', 'templates');
@@ -245,7 +246,7 @@ export function buildRowReplacements(row, opts) {
   return {
     '{{ROW_INDEX}}': String(row.index),
     '{{ROW_SELECTOR}}': row.selector
-      || `header > :nth-child(${row.index + 1})`,
+      || `header .header > :nth-child(${row.index + 1})`,
     '{{ROW_SESSION}}': `row-${row.index}-eval`,
     '{{ROW_HEIGHT}}': String(Math.round(row.bounds.height)),
     '{{ROW_SECTION_STYLE}}': row.suggestedSectionStyle
@@ -406,7 +407,7 @@ function mainInitCss(args) {
   log(`  ${rows.length} row stubs + header.css created`);
 }
 
-async function mainRow(args) {
+function mainRow(args) {
   const rows = loadRowFiles(args.rowsDir);
   const row = rows.find((r) => r.index === args.rowIndex);
   if (!row) {
@@ -425,10 +426,10 @@ async function mainRow(args) {
   // Crop source screenshot for this row using pngjs
   const desktopPath = join(sourceOutDir, 'desktop.png');
   if (existsSync(desktopPath)) {
-    const pngjsPath = join(
-      autoresearchDir, 'node_modules', 'pngjs', 'lib', 'pngjs.js',
+    const require = createRequire(
+      join(autoresearchDir, 'package.json'),
     );
-    const { PNG } = await import(pngjsPath);
+    const { PNG } = require('pngjs');
     const srcData = readFileSync(desktopPath);
     const srcPng = PNG.sync.read(srcData);
 
@@ -598,7 +599,7 @@ function mainFull(args) {
   log(`  Run: cd ${args.targetDir} && ./loop.sh`);
 }
 
-async function main() {
+function main() {
   const args = parseArgs(process.argv);
   if (args.mode === 'init-css') return mainInitCss(args);
   if (args.mode === 'row') return mainRow(args);
@@ -608,8 +609,5 @@ async function main() {
 const isDirectRun = process.argv[1]
   && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectRun) {
-  main().catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+  main();
 }

--- a/skills/migrate-header/templates/evaluate-row.js.tmpl
+++ b/skills/migrate-header/templates/evaluate-row.js.tmpl
@@ -7,11 +7,12 @@
  * Output: JSON to stdout with score and breakdown
  */
 import {
-  readFileSync, writeFileSync, existsSync, mkdirSync,
+  readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync,
 } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
@@ -97,38 +98,36 @@ function compareImages(sourcePath, renderedPath, diffPath) {
 }
 
 function takeElementScreenshot(outputPath) {
-  // Use run-code with locator.screenshot() — screenshot [ref] only accepts
-  // snapshot refs (e5), not CSS selectors. locator.screenshot() is the
-  // proper Playwright API for element-level screenshots.
-  const escapedSelector = ROW_SELECTOR.replace(/'/g, "\\'");
-  const escapedPath = outputPath.replace(/'/g, "\\'");
-  const code = `async page => {`
-    + ` await page.locator('${escapedSelector}').screenshot({ path: '${escapedPath}' });`
-    + ` return 'ok';`
-    + ` }`;
-  try {
+  // Use run-code --filename with locator.screenshot() — the screenshot
+  // command only accepts snapshot refs (e5), not CSS selectors.
+  const scriptPath = join(tmpdir(), `row-screenshot-${process.pid}.js`);
+  writeFileSync(scriptPath, `async page => {
+  await page.locator(${JSON.stringify(ROW_SELECTOR)})
+    .screenshot({ path: ${JSON.stringify(outputPath)} });
+  return 'ok';
+}`);
+
+  function runScreenshot() {
     execFileSync(
       'playwright-cli',
-      [`-s=${SESSION}`, '--raw', 'run-code', code],
-      EXEC_OPTS,
-    );
-    if (existsSync(outputPath) && readFileSync(outputPath).length > 0) {
-      return true;
-    }
-  } catch {
-    // Fall through to retry
-  }
-  // Retry once after settling
-  execFileSync('sleep', ['2']);
-  try {
-    execFileSync(
-      'playwright-cli',
-      [`-s=${SESSION}`, '--raw', 'run-code', code],
+      [`-s=${SESSION}`, '--raw', 'run-code', `--filename=${scriptPath}`],
       EXEC_OPTS,
     );
     return existsSync(outputPath) && readFileSync(outputPath).length > 0;
+  }
+
+  try {
+    if (runScreenshot()) return true;
+  } catch {
+    // Fall through to retry
+  }
+  execFileSync('sleep', ['2']);
+  try {
+    return runScreenshot();
   } catch {
     return false;
+  } finally {
+    try { unlinkSync(scriptPath); } catch { /* noop */ }
   }
 }
 

--- a/skills/migrate-header/templates/evaluate-row.js.tmpl
+++ b/skills/migrate-header/templates/evaluate-row.js.tmpl
@@ -14,7 +14,6 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
-import { parseEvalOutput } from '{{SKILL_HOME}}/scripts/cdp-helpers.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SOURCE_DIR = join(__dirname, 'source');
@@ -34,10 +33,6 @@ function cli(...args) {
   return execFileSync(
     'playwright-cli', [`-s=${SESSION}`, ...args], EXEC_OPTS,
   ).trim();
-}
-
-function cliEval(js) {
-  return parseEvalOutput(cli('eval', js));
 }
 
 function compareImages(sourcePath, renderedPath, diffPath) {

--- a/skills/migrate-header/templates/evaluate-row.js.tmpl
+++ b/skills/migrate-header/templates/evaluate-row.js.tmpl
@@ -1,0 +1,173 @@
+/** IMMUTABLE EVALUATOR — the agent must not modify this file.
+ *
+ * Captures a single header row element, compares against cropped source,
+ * and outputs a pixelmatch score. Used by loop-row-N.sh for keep/discard.
+ *
+ * Usage: node autoresearch/evaluate-row-{{ROW_INDEX}}.js <port> <iteration>
+ * Output: JSON to stdout with score and breakdown
+ */
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+import { parseEvalOutput } from '{{SKILL_HOME}}/scripts/cdp-helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SOURCE_DIR = join(__dirname, 'source');
+const RESULTS_DIR = join(__dirname, 'results', 'row-{{ROW_INDEX}}');
+const PORT = process.argv[2] || '{{PORT}}';
+const PAGE_PATH = '{{PAGE_PATH}}';
+const ITERATION = process.argv[3] || 'latest';
+const BASE_URL = `http://localhost:${PORT}${PAGE_PATH}`;
+const SESSION = '{{ROW_SESSION}}';
+const ROW_SELECTOR = '{{ROW_SELECTOR}}';
+
+mkdirSync(RESULTS_DIR, { recursive: true });
+
+const EXEC_OPTS = { encoding: 'utf-8', timeout: 30000 };
+
+function cli(...args) {
+  return execFileSync(
+    'playwright-cli', [`-s=${SESSION}`, ...args], EXEC_OPTS,
+  ).trim();
+}
+
+function cliEval(js) {
+  return parseEvalOutput(cli('eval', js));
+}
+
+function compareImages(sourcePath, renderedPath, diffPath) {
+  if (!existsSync(sourcePath)) return { similarity: 0, error: 'source missing' };
+  if (!existsSync(renderedPath)) return { similarity: 0, error: 'rendered missing' };
+
+  const sourceImg = PNG.sync.read(readFileSync(sourcePath));
+  const renderedImg = PNG.sync.read(readFileSync(renderedPath));
+
+  const width = Math.max(sourceImg.width, renderedImg.width);
+  const height = Math.max(sourceImg.height, renderedImg.height);
+
+  const padPng = (img, w, h) => {
+    const padded = new PNG({ width: w, height: h });
+    for (let i = 0; i < padded.data.length; i += 4) {
+      padded.data[i] = 255;
+      padded.data[i + 1] = 255;
+      padded.data[i + 2] = 255;
+      padded.data[i + 3] = 255;
+    }
+    for (let y = 0; y < img.height && y < h; y++) {
+      for (let x = 0; x < img.width && x < w; x++) {
+        const srcIdx = (y * img.width + x) * 4;
+        const dstIdx = (y * w + x) * 4;
+        padded.data[dstIdx] = img.data[srcIdx];
+        padded.data[dstIdx + 1] = img.data[srcIdx + 1];
+        padded.data[dstIdx + 2] = img.data[srcIdx + 2];
+        padded.data[dstIdx + 3] = img.data[srcIdx + 3];
+      }
+    }
+    return padded;
+  };
+
+  const src = sourceImg.width === width && sourceImg.height === height
+    ? sourceImg : padPng(sourceImg, width, height);
+  const ren = renderedImg.width === width && renderedImg.height === height
+    ? renderedImg : padPng(renderedImg, width, height);
+
+  const diff = new PNG({ width, height });
+  const mismatchedPixels = pixelmatch(
+    src.data,
+    ren.data,
+    diff.data,
+    width,
+    height,
+    { threshold: 0.15, alpha: 0.5 },
+  );
+
+  writeFileSync(diffPath, PNG.sync.write(diff));
+
+  const totalPixels = width * height;
+  const similarity = ((totalPixels - mismatchedPixels) / totalPixels) * 100;
+  return {
+    similarity: Math.round(similarity * 100) / 100,
+    mismatchedPixels,
+    totalPixels,
+    width,
+    height,
+    sourceHeight: sourceImg.height,
+    renderedHeight: renderedImg.height,
+  };
+}
+
+function takeElementScreenshot(outputPath) {
+  try {
+    cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${outputPath}`);
+    if (existsSync(outputPath) && readFileSync(outputPath).length > 0) {
+      return true;
+    }
+  } catch {
+    // Fall through to retry
+  }
+  // Retry once after settling
+  execFileSync('sleep', ['2']);
+  try {
+    cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${outputPath}`);
+    return existsSync(outputPath) && readFileSync(outputPath).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Main evaluation
+const results = { viewports: {}, compositeScore: 0 };
+
+try {
+  cli('open', BASE_URL);
+} catch (err) {
+  console.error(JSON.stringify({ error: `Failed to open ${BASE_URL}: ${err.message}` }));
+  process.exit(1);
+}
+
+const sourcePath = join(SOURCE_DIR, `desktop-row-{{ROW_INDEX}}.png`);
+const renderedPath = join(RESULTS_DIR, 'desktop-rendered.png');
+const diffPath = join(RESULTS_DIR, 'desktop-diff.png');
+
+try {
+  cli('resize', '1440', '900');
+  execFileSync('sleep', ['2']);
+
+  const captured = takeElementScreenshot(renderedPath);
+
+  if (captured) {
+    const iterPath = join(RESULTS_DIR, `desktop-rendered-${ITERATION}.png`);
+    writeFileSync(iterPath, readFileSync(renderedPath));
+
+    const comparison = compareImages(sourcePath, renderedPath, diffPath);
+    results.viewports.desktop = { ...comparison, weight: 1.0 };
+  } else {
+    results.viewports.desktop = {
+      similarity: 0, error: 'element screenshot failed', weight: 1.0,
+    };
+  }
+} catch (err) {
+  results.viewports.desktop = {
+    similarity: 0, error: err.message, weight: 1.0,
+  };
+}
+
+try {
+  cli('close');
+} catch {
+  // Session may already be closed
+}
+
+results.compositeScore = results.viewports.desktop?.similarity || 0;
+
+console.log(JSON.stringify(results, null, 2));
+
+writeFileSync(
+  join(RESULTS_DIR, 'latest-evaluation.json'),
+  JSON.stringify(results, null, 2),
+);

--- a/skills/migrate-header/templates/evaluate-row.js.tmpl
+++ b/skills/migrate-header/templates/evaluate-row.js.tmpl
@@ -97,8 +97,21 @@ function compareImages(sourcePath, renderedPath, diffPath) {
 }
 
 function takeElementScreenshot(outputPath) {
+  // Use run-code with locator.screenshot() — screenshot [ref] only accepts
+  // snapshot refs (e5), not CSS selectors. locator.screenshot() is the
+  // proper Playwright API for element-level screenshots.
+  const escapedSelector = ROW_SELECTOR.replace(/'/g, "\\'");
+  const escapedPath = outputPath.replace(/'/g, "\\'");
+  const code = `async page => {`
+    + ` await page.locator('${escapedSelector}').screenshot({ path: '${escapedPath}' });`
+    + ` return 'ok';`
+    + ` }`;
   try {
-    cli('screenshot', ROW_SELECTOR, `--filename=${outputPath}`);
+    execFileSync(
+      'playwright-cli',
+      [`-s=${SESSION}`, '--raw', 'run-code', code],
+      EXEC_OPTS,
+    );
     if (existsSync(outputPath) && readFileSync(outputPath).length > 0) {
       return true;
     }
@@ -108,7 +121,11 @@ function takeElementScreenshot(outputPath) {
   // Retry once after settling
   execFileSync('sleep', ['2']);
   try {
-    cli('screenshot', ROW_SELECTOR, `--filename=${outputPath}`);
+    execFileSync(
+      'playwright-cli',
+      [`-s=${SESSION}`, '--raw', 'run-code', code],
+      EXEC_OPTS,
+    );
     return existsSync(outputPath) && readFileSync(outputPath).length > 0;
   } catch {
     return false;

--- a/skills/migrate-header/templates/evaluate-row.js.tmpl
+++ b/skills/migrate-header/templates/evaluate-row.js.tmpl
@@ -12,7 +12,6 @@ import {
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
-import { tmpdir } from 'node:os';
 import { PNG } from 'pngjs';
 import pixelmatch from 'pixelmatch';
 
@@ -100,7 +99,10 @@ function compareImages(sourcePath, renderedPath, diffPath) {
 function takeElementScreenshot(outputPath) {
   // Use run-code --filename with locator.screenshot() — the screenshot
   // command only accepts snapshot refs (e5), not CSS selectors.
-  const scriptPath = join(tmpdir(), `row-screenshot-${process.pid}.js`);
+  // Write to .playwright-cli/ which is inside the sandbox's allowed roots
+  const pwDir = join(dirname(__dirname), '.playwright-cli');
+  mkdirSync(pwDir, { recursive: true });
+  const scriptPath = join(pwDir, `row-screenshot-${process.pid}.js`);
   writeFileSync(scriptPath, `async page => {
   await page.locator(${JSON.stringify(ROW_SELECTOR)})
     .screenshot({ path: ${JSON.stringify(outputPath)} });

--- a/skills/migrate-header/templates/evaluate-row.js.tmpl
+++ b/skills/migrate-header/templates/evaluate-row.js.tmpl
@@ -98,7 +98,7 @@ function compareImages(sourcePath, renderedPath, diffPath) {
 
 function takeElementScreenshot(outputPath) {
   try {
-    cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${outputPath}`);
+    cli('screenshot', ROW_SELECTOR, `--filename=${outputPath}`);
     if (existsSync(outputPath) && readFileSync(outputPath).length > 0) {
       return true;
     }
@@ -108,7 +108,7 @@ function takeElementScreenshot(outputPath) {
   // Retry once after settling
   execFileSync('sleep', ['2']);
   try {
-    cli('screenshot', `--selector=${ROW_SELECTOR}`, `--filename=${outputPath}`);
+    cli('screenshot', ROW_SELECTOR, `--filename=${outputPath}`);
     return existsSync(outputPath) && readFileSync(outputPath).length > 0;
   } catch {
     return false;

--- a/skills/migrate-header/templates/judge-first.md.tmpl
+++ b/skills/migrate-header/templates/judge-first.md.tmpl
@@ -65,10 +65,10 @@ Ignore minor subpixel differences, antialiasing, and font rendering variations.
 
 **Respond with ONLY this JSON (no markdown fences, no other text):**
 
-{"improved": true, "layout_ok": false, "precision_ok": false, "active_gate": 1, "confidence": "high", "reasoning": "Logo is on the right but source has it on the left.", "structure_issues": ["logo on wrong side"], "precision_issues": [], "diagnosis": ["move logo to the left"]}
+{"improved": false, "layout_ok": false, "precision_ok": false, "active_gate": 1, "confidence": "high", "reasoning": "Logo is on the right but source has it on the left.", "structure_issues": ["logo on wrong side"], "precision_issues": [], "diagnosis": ["move logo to the left"]}
 
 Rules for the JSON:
-- "improved": true if the header renders with recognizable structure, false if it is broken or empty
+- "improved": true ONLY if layout_ok is true. A structurally broken render (missing elements, wrong positions, wrong sizes) is NEVER an improvement, even on the first iteration. Set false if layout_ok is false.
 - "layout_ok": false unless ALL Gate 1 checks pass
 - "precision_ok": false unless Gate 2 passes (always false if layout_ok is false)
 - "active_gate": 1, 2, or 3 — the gate that produced the diagnosis

--- a/skills/migrate-header/templates/loop-row.sh.tmpl
+++ b/skills/migrate-header/templates/loop-row.sh.tmpl
@@ -6,9 +6,9 @@ set -euo pipefail
 # file-scoped git ratchet with plateau detection.
 
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
-EVALUATE="node ${PROJECT_DIR}/autoresearch/evaluate.js"
+EVALUATE="node ${PROJECT_DIR}/autoresearch/evaluate-row-{{ROW_INDEX}}.js"
 RESULTS_FILE="${PROJECT_DIR}/results-row-{{ROW_INDEX}}.tsv"
-PROGRAM_FILE="${PROJECT_DIR}/program.md"
+PROGRAM_FILE="${PROJECT_DIR}/program-row-{{ROW_INDEX}}.md"
 PORT="${AEM_PORT:-{{PORT}}}"
 MAX_ITERATIONS="${MAX_ITERATIONS:-{{MAX_ITERATIONS}}}"
 MAX_CONSECUTIVE_REVERTS="${MAX_CONSECUTIVE_REVERTS:-{{MAX_CONSECUTIVE_REVERTS}}}"
@@ -42,7 +42,7 @@ cleanup() {
     log "Consecutive reverts at exit: ${CONSECUTIVE_REVERTS}"
   fi
   # Clean up any temp backups
-  rm -f "/tmp/row-{{ROW_INDEX}}-backup-$$.css"
+  rm -f /tmp/row-{{ROW_INDEX}}-backup-*-$$.css
   exit 0
 }
 trap cleanup SIGINT SIGTERM

--- a/skills/migrate-header/templates/loop-row.sh.tmpl
+++ b/skills/migrate-header/templates/loop-row.sh.tmpl
@@ -268,11 +268,20 @@ while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
   # Write judge feedback for next iteration's polish agent
   echo "${judge_detail}" > "${ROW_RESULTS_DIR}/judge-feedback.json"
 
+  # Extract layout_ok from judge detail to veto broken states
+  layout_ok=$(echo "${judge_detail}" | node --input-type=commonjs -e "
+    const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    console.log(d.layout_ok ? 'true' : 'false');
+  " 2>/dev/null || echo "true")
+
   # Composite: pixelmatch 50% + judge 50%
+  # Veto: layout_ok=false caps score at 50 so broken states can't lock in
   score=$(node -e "
     const pm = ${desktop} || 0;
     const judge = ${judge_score} || 50;
-    console.log(Math.round((pm * 0.50 + judge * 0.50) * 100) / 100);
+    const layoutOk = '${layout_ok}' === 'true';
+    const raw = Math.round((pm * 0.50 + judge * 0.50) * 100) / 100;
+    console.log(layoutOk ? raw : Math.min(raw, 50));
   " 2>/dev/null || echo "0")
 
   # Compare with best — strict improvement required

--- a/skills/migrate-header/templates/loop-row.sh.tmpl
+++ b/skills/migrate-header/templates/loop-row.sh.tmpl
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Autoresearch loop for a single EDS header row (row-{{ROW_INDEX}}).
+# Outer loop: fresh claude session each iteration, immutable evaluator,
+# file-scoped git ratchet with plateau detection.
+
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EVALUATE="node ${PROJECT_DIR}/autoresearch/evaluate.js"
+RESULTS_FILE="${PROJECT_DIR}/results-row-{{ROW_INDEX}}.tsv"
+PROGRAM_FILE="${PROJECT_DIR}/program.md"
+PORT="${AEM_PORT:-{{PORT}}}"
+MAX_ITERATIONS="${MAX_ITERATIONS:-{{MAX_ITERATIONS}}}"
+MAX_CONSECUTIVE_REVERTS="${MAX_CONSECUTIVE_REVERTS:-{{MAX_CONSECUTIVE_REVERTS}}}"
+ROW_CSS="blocks/header/row-{{ROW_INDEX}}.css"
+ROW_RESULTS_DIR="${PROJECT_DIR}/autoresearch/results/row-{{ROW_INDEX}}"
+BEST_SCORE=0
+ITERATION=0
+CONSECUTIVE_REVERTS=0
+BEST_KEPT_ITERATION=0
+JUDGE_TMPL_DIR="{{SKILL_HOME}}/templates"
+JUDGE_NEUTRAL=$'50\t{"layout_ok":true,"precision_ok":false,"active_gate":1,"diagnosis":[],"structure_issues":[],"precision_issues":[],"reasoning":""}'
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${BLUE}[row-{{ROW_INDEX}}]${NC} $1"; }
+ok()  { echo -e "${GREEN}[row-{{ROW_INDEX}}]${NC} $1"; }
+warn() { echo -e "${YELLOW}[row-{{ROW_INDEX}}]${NC} $1"; }
+err() { echo -e "${RED}[row-{{ROW_INDEX}}]${NC} $1"; }
+
+cleanup() {
+  echo ""
+  log "Stopping... Final best score: ${BEST_SCORE}"
+  if [[ -f "${RESULTS_FILE}" ]]; then
+    log "Results saved to ${RESULTS_FILE}"
+    log "Total iterations: ${ITERATION}"
+    log "Consecutive reverts at exit: ${CONSECUTIVE_REVERTS}"
+  fi
+  # Clean up any temp backups
+  rm -f "/tmp/row-{{ROW_INDEX}}-backup-$$.css"
+  exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+# Initialize results file
+if [[ ! -f "${RESULTS_FILE}" ]]; then
+  printf "iteration\tcommit\tscore\tvisual_desktop\tjudge\tstatus\tdescription\n" \
+    > "${RESULTS_FILE}"
+fi
+
+# Resume support: read best score and iteration count from existing results
+if [[ -f "${RESULTS_FILE}" ]]; then
+  existing_best=$(tail -n +2 "${RESULTS_FILE}" \
+    | awk -F'\t' '{print $3}' | sort -rn | head -1)
+  if [[ -n "${existing_best}" ]]; then
+    BEST_SCORE="${existing_best}"
+    ITERATION=$(tail -n +2 "${RESULTS_FILE}" | wc -l | tr -d ' ')
+    log "Resuming from iteration ${ITERATION}, best score: ${BEST_SCORE}"
+  fi
+fi
+
+# Check dev server is reachable
+check_server() {
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "http://localhost:${PORT}/" 2>/dev/null) || true
+  if [[ "${status}" != "200" ]]; then
+    err "Dev server not running on port ${PORT}."
+    err "Start it with: cd ${PROJECT_DIR} && aem up --html-folder ."
+    exit 1
+  fi
+}
+
+# Run evaluator and extract composite score
+run_evaluation() {
+  local eval_output
+  eval_output=$(${EVALUATE} "${PORT}" "${ITERATION}" 2>/dev/null) || true
+
+  if [[ -z "${eval_output}" ]]; then
+    echo "0|0"
+    return
+  fi
+
+  echo "${eval_output}" | node --input-type=commonjs -e "
+    const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    const fields = [
+      d.compositeScore||0,
+      d.viewports?.desktop?.similarity||0,
+    ];
+    console.log(fields.join('|'));
+  " 2>/dev/null || echo "0|0"
+}
+
+# Run LLM judge: compare source + before + after screenshots + CSS queries
+run_judge() {
+  local iteration=$1
+  local source_img="${PROJECT_DIR}/autoresearch/source/desktop-row-{{ROW_INDEX}}.png"
+  local styles_json="${PROJECT_DIR}/autoresearch/extraction/styles.json"
+  local css_query="{{SKILL_HOME}}/scripts/css-query.js"
+  local after_img="${ROW_RESULTS_DIR}/desktop-rendered-${iteration}.png"
+  local judge_prompt_file="/tmp/judge-prompt-row-{{ROW_INDEX}}-$$.md"
+
+  if [[ ! -f "${after_img}" ]]; then
+    warn "Judge: after screenshot not found, skipping"
+    printf '%s\n' "${JUDGE_NEUTRAL}"
+    return
+  fi
+
+  # Common sed replacements for both templates
+  local common_seds=(
+    -e "s|{{SOURCE_IMG}}|${source_img}|g"
+    -e "s|{{AFTER_IMG}}|${after_img}|g"
+    -e "s|{{AFTER_ITERATION}}|${iteration}|g"
+    -e "s|{{STYLES_JSON}}|${styles_json}|g"
+    -e "s|{{CSS_QUERY}}|${css_query}|g"
+    -e "s|{{PORT}}|${PORT}|g"
+  )
+
+  # Build judge prompt from template
+  if [[ ${BEST_KEPT_ITERATION} -eq 0 ]]; then
+    local tmpl="${JUDGE_TMPL_DIR}/judge-first.md.tmpl"
+    if [[ ! -f "${tmpl}" ]]; then
+      warn "Judge: first-iteration template not found, skipping"
+      printf '%s\n' "${JUDGE_NEUTRAL}"
+      return
+    fi
+    sed "${common_seds[@]}" "${tmpl}" > "${judge_prompt_file}"
+  else
+    local before_img="${ROW_RESULTS_DIR}/desktop-rendered-${BEST_KEPT_ITERATION}.png"
+    local tmpl="${JUDGE_TMPL_DIR}/judge.md.tmpl"
+    if [[ ! -f "${tmpl}" ]]; then
+      warn "Judge: template not found, skipping"
+      printf '%s\n' "${JUDGE_NEUTRAL}"
+      return
+    fi
+    if [[ ! -f "${before_img}" ]]; then
+      warn "Judge: before screenshot not found, using first-iteration template"
+      tmpl="${JUDGE_TMPL_DIR}/judge-first.md.tmpl"
+      sed "${common_seds[@]}" "${tmpl}" > "${judge_prompt_file}"
+    else
+      sed "${common_seds[@]}" \
+          -e "s|{{BEFORE_IMG}}|${before_img}|g" \
+          -e "s|{{BEFORE_ITERATION}}|${BEST_KEPT_ITERATION}|g" \
+          "${tmpl}" > "${judge_prompt_file}"
+    fi
+  fi
+
+  # Open css-query session on rendered page for Gate 2
+  node "${css_query}" open "http://localhost:${PORT}/" \
+    --session=row-{{ROW_INDEX}}-judge 2>/dev/null || true
+
+  # Invoke judge (Read for images/styles, Bash for css-query)
+  local judge_raw
+  judge_raw=$(claude -p "$(cat "${judge_prompt_file}")" \
+    --allowedTools "Read,Bash" \
+    --output-format json \
+    2>"${ROW_RESULTS_DIR}/judge-stderr.log") || true
+  rm -f "${judge_prompt_file}"
+
+  # Close css-query session
+  node "${css_query}" close \
+    --session=row-{{ROW_INDEX}}-judge 2>/dev/null || true
+
+  if [[ -z "${judge_raw}" ]]; then
+    warn "Judge: no output, defaulting to neutral"
+    printf '%s\n' "${JUDGE_NEUTRAL}"
+    return
+  fi
+
+  # Parse judge output — unwrap --output-format json envelope, then parse model response
+  echo "${judge_raw}" | node --input-type=commonjs -e "
+    const raw = require('fs').readFileSync('/dev/stdin', 'utf-8').trim();
+    try {
+      const envelope = JSON.parse(raw);
+      const d = JSON.parse(envelope.result);
+      const score = d.improved === true ? 100 : (d.improved === false ? 0 : 50);
+      const detail = JSON.stringify({
+        layout_ok: d.layout_ok === true,
+        precision_ok: d.precision_ok === true,
+        active_gate: d.active_gate || 1,
+        diagnosis: d.diagnosis || [],
+        structure_issues: d.structure_issues || [],
+        precision_issues: d.precision_issues || [],
+        reasoning: d.reasoning || '',
+      });
+      console.log(score + '\t' + detail);
+    } catch {
+      console.log('50\t' + JSON.stringify({layout_ok:true,precision_ok:false,active_gate:1,diagnosis:[],structure_issues:[],precision_issues:[],reasoning:''}));
+    }
+  " 2>/dev/null || printf '%s\n' "${JUDGE_NEUTRAL}"
+}
+
+# Main loop
+log "Starting row-{{ROW_INDEX}} autoresearch loop"
+log "Max iterations: ${MAX_ITERATIONS}"
+log "Plateau threshold: ${MAX_CONSECUTIVE_REVERTS} consecutive reverts"
+log "Evaluator: ${EVALUATE}"
+log "Row CSS: ${ROW_CSS}"
+echo ""
+
+check_server
+mkdir -p "${ROW_RESULTS_DIR}"
+
+while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
+  ITERATION=$((ITERATION + 1))
+  log "=== Iteration ${ITERATION}/${MAX_ITERATIONS} (best: ${BEST_SCORE}, reverts: ${CONSECUTIVE_REVERTS}/${MAX_CONSECUTIVE_REVERTS}) ==="
+
+  # Backup current row CSS before agent session
+  css_backup="/tmp/row-{{ROW_INDEX}}-backup-${ITERATION}-$$.css"
+  if [[ -f "${PROJECT_DIR}/${ROW_CSS}" ]]; then
+    cp "${PROJECT_DIR}/${ROW_CSS}" "${css_backup}"
+  else
+    touch "${css_backup}"
+  fi
+
+  # Fresh claude session with program.md (must cd — claude has no --cwd flag)
+  log "Launching fresh Claude session..."
+  (cd "${PROJECT_DIR}" && claude -p "$(cat "${PROGRAM_FILE}")" \
+    --allowedTools "Edit,Write,Read,Glob,Grep,Bash" \
+    > /dev/null 2>&1) || true
+
+  # Check if row CSS changed (diff backup vs current)
+  css_changed=false
+  if ! diff -q "${css_backup}" "${PROJECT_DIR}/${ROW_CSS}" > /dev/null 2>&1; then
+    css_changed=true
+  fi
+
+  # Check for staged/unstaged changes too (agent may not have touched row CSS directly)
+  has_uncommitted=false
+  git -C "${PROJECT_DIR}" diff --quiet 2>/dev/null || has_uncommitted=true
+  git -C "${PROJECT_DIR}" diff --cached --quiet 2>/dev/null \
+    || has_uncommitted=true
+
+  if [[ "${css_changed}" == "false" ]] && [[ "${has_uncommitted}" == "false" ]]; then
+    warn "No changes to ${ROW_CSS} detected, skipping evaluation"
+    printf "%d\t-\t%s\t-\t-\tno_changes\tAgent made no modifications\n" \
+      "${ITERATION}" "${BEST_SCORE}" >> "${RESULTS_FILE}"
+    rm -f "${css_backup}"
+    CONSECUTIVE_REVERTS=$((CONSECUTIVE_REVERTS + 1))
+    if [[ ${CONSECUTIVE_REVERTS} -ge ${MAX_CONSECUTIVE_REVERTS} ]]; then
+      err "Plateau: ${CONSECUTIVE_REVERTS} consecutive non-improvements. Stopping."
+      break
+    fi
+    continue
+  fi
+
+  # Stage and commit the row CSS (and any other uncommitted changes)
+  if [[ "${has_uncommitted}" == "true" ]] || [[ "${css_changed}" == "true" ]]; then
+    git -C "${PROJECT_DIR}" add "${ROW_CSS}" 2>/dev/null || true
+    # Stage any other modified files the agent touched
+    git -C "${PROJECT_DIR}" add -u 2>/dev/null || true
+    git -C "${PROJECT_DIR}" commit \
+      -m "row-{{ROW_INDEX}}-iteration-${ITERATION}: agent modifications" \
+      2>/dev/null || true
+  fi
+
+  local_commit=$(git -C "${PROJECT_DIR}" rev-parse --short HEAD)
+  commit_msg=$(git -C "${PROJECT_DIR}" log -1 --format=%s)
+
+  # Run immutable evaluator
+  log "Running evaluation..."
+  eval_result=$(run_evaluation)
+  IFS='|' read -r _eval_composite desktop <<< "${eval_result}"
+
+  # Run LLM judge
+  log "Running judge comparison..."
+  judge_result=$(run_judge "${ITERATION}")
+  IFS=$'\t' read -r judge_score judge_detail <<< "${judge_result}"
+
+  # Write judge feedback for next iteration's polish agent
+  echo "${judge_detail}" > "${ROW_RESULTS_DIR}/judge-feedback.json"
+
+  # Composite: pixelmatch 50% + judge 50%
+  score=$(node -e "
+    const pm = ${desktop} || 0;
+    const judge = ${judge_score} || 50;
+    console.log(Math.round((pm * 0.50 + judge * 0.50) * 100) / 100);
+  " 2>/dev/null || echo "0")
+
+  # Compare with best — strict improvement required
+  keep=$(node -e "console.log(${score} > ${BEST_SCORE} ? 'yes' : 'no')" \
+    2>/dev/null || echo "no")
+
+  if [[ "${keep}" == "yes" ]]; then
+    iteration_status="kept"
+    ok "IMPROVED: ${BEST_SCORE} -> ${score} (desktop=${desktop}, judge=${judge_score})"
+    BEST_SCORE="${score}"
+    BEST_KEPT_ITERATION=${ITERATION}
+    CONSECUTIVE_REVERTS=0
+    printf "%d\t%s\t%s\t%s\t%s\timproved\t%s\n" \
+      "${ITERATION}" "${local_commit}" "${score}" \
+      "${desktop}" "${judge_score}" \
+      "${commit_msg}" \
+      >> "${RESULTS_FILE}"
+  else
+    iteration_status="reverted"
+    warn "NO IMPROVEMENT: ${score} <= ${BEST_SCORE} (judge=${judge_score}) — reverting"
+    # Save the diff before reverting
+    git -C "${PROJECT_DIR}" diff HEAD~1 HEAD -- "${ROW_CSS}" \
+      > "${ROW_RESULTS_DIR}/last-reverted.diff" \
+      2>/dev/null || true
+    # Undo commit and restore file (no reset --hard — file-scoped only)
+    git -C "${PROJECT_DIR}" reset --soft HEAD~1 2>/dev/null || true
+    git -C "${PROJECT_DIR}" checkout -- "${ROW_CSS}" 2>/dev/null || true
+    CONSECUTIVE_REVERTS=$((CONSECUTIVE_REVERTS + 1))
+    printf "%d\t%s\t%s\t%s\t%s\treverted\t%s\n" \
+      "${ITERATION}" "${local_commit}" "${score}" \
+      "${desktop}" "${judge_score}" \
+      "${commit_msg}" \
+      >> "${RESULTS_FILE}"
+
+    if [[ ${CONSECUTIVE_REVERTS} -ge ${MAX_CONSECUTIVE_REVERTS} ]]; then
+      err "Plateau: ${CONSECUTIVE_REVERTS} consecutive non-improvements. Stopping."
+      rm -f "${css_backup}"
+      break
+    fi
+  fi
+
+  # Append to cumulative judge history (survives git reverts)
+  node -e "
+    const fs = require('fs');
+    const detail = JSON.parse(process.argv[1] || '{}');
+    const entry = {
+      ...detail,
+      iteration: ${ITERATION},
+      composite: ${score},
+      desktop: ${desktop},
+      judge: ${judge_score},
+      status: '${iteration_status}',
+    };
+    fs.appendFileSync(
+      '${ROW_RESULTS_DIR}/judge-history.jsonl',
+      JSON.stringify(entry) + '\n'
+    );
+  " "${judge_detail}" 2>/dev/null || true
+
+  # Clean up iteration backup
+  rm -f "${css_backup}"
+
+  echo ""
+done
+
+log "Loop finished. Best score: ${BEST_SCORE} after ${ITERATION} iterations."

--- a/skills/migrate-header/templates/loop-row.sh.tmpl
+++ b/skills/migrate-header/templates/loop-row.sh.tmpl
@@ -230,13 +230,7 @@ while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
     css_changed=true
   fi
 
-  # Check for staged/unstaged changes too (agent may not have touched row CSS directly)
-  has_uncommitted=false
-  git -C "${PROJECT_DIR}" diff --quiet 2>/dev/null || has_uncommitted=true
-  git -C "${PROJECT_DIR}" diff --cached --quiet 2>/dev/null \
-    || has_uncommitted=true
-
-  if [[ "${css_changed}" == "false" ]] && [[ "${has_uncommitted}" == "false" ]]; then
+  if [[ "${css_changed}" == "false" ]]; then
     warn "No changes to ${ROW_CSS} detected, skipping evaluation"
     printf "%d\t-\t%s\t-\t-\tno_changes\tAgent made no modifications\n" \
       "${ITERATION}" "${BEST_SCORE}" >> "${RESULTS_FILE}"
@@ -249,11 +243,10 @@ while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
     continue
   fi
 
-  # Stage and commit the row CSS (and any other uncommitted changes)
-  if [[ "${has_uncommitted}" == "true" ]] || [[ "${css_changed}" == "true" ]]; then
+  # Stage and commit ONLY this row's CSS — never stage other files
+  # to avoid capturing concurrent changes from parallel row agents
+  if [[ "${css_changed}" == "true" ]]; then
     git -C "${PROJECT_DIR}" add "${ROW_CSS}" 2>/dev/null || true
-    # Stage any other modified files the agent touched
-    git -C "${PROJECT_DIR}" add -u 2>/dev/null || true
     git -C "${PROJECT_DIR}" commit \
       -m "row-{{ROW_INDEX}}-iteration-${ITERATION}: agent modifications" \
       2>/dev/null || true
@@ -301,12 +294,15 @@ while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
     iteration_status="reverted"
     warn "NO IMPROVEMENT: ${score} <= ${BEST_SCORE} (judge=${judge_score}) — reverting"
     # Save the diff before reverting
-    git -C "${PROJECT_DIR}" diff HEAD~1 HEAD -- "${ROW_CSS}" \
+    diff "${css_backup}" "${PROJECT_DIR}/${ROW_CSS}" \
       > "${ROW_RESULTS_DIR}/last-reverted.diff" \
       2>/dev/null || true
-    # Undo commit and restore file (no reset --hard — file-scoped only)
-    git -C "${PROJECT_DIR}" reset --soft HEAD~1 2>/dev/null || true
-    git -C "${PROJECT_DIR}" checkout -- "${ROW_CSS}" 2>/dev/null || true
+    # Restore from backup and commit (forward-only — safe for parallel agents)
+    cp "${css_backup}" "${PROJECT_DIR}/${ROW_CSS}"
+    git -C "${PROJECT_DIR}" add "${ROW_CSS}" 2>/dev/null || true
+    git -C "${PROJECT_DIR}" commit \
+      -m "row-{{ROW_INDEX}}-iteration-${ITERATION}: reverted" \
+      2>/dev/null || true
     CONSECUTIVE_REVERTS=$((CONSECUTIVE_REVERTS + 1))
     printf "%d\t%s\t%s\t%s\t%s\treverted\t%s\n" \
       "${ITERATION}" "${local_commit}" "${score}" \

--- a/skills/migrate-header/templates/loop.sh.tmpl
+++ b/skills/migrate-header/templates/loop.sh.tmpl
@@ -259,12 +259,21 @@ while [[ ${ITERATION} -lt ${MAX_ITERATIONS} ]]; do
   # Write judge feedback for next iteration's polish agent
   echo "${judge_detail}" > "${PROJECT_DIR}/autoresearch/results/judge-feedback.json"
 
+  # Extract layout_ok from judge detail to veto broken states
+  layout_ok=$(echo "${judge_detail}" | node --input-type=commonjs -e "
+    const d = JSON.parse(require('fs').readFileSync('/dev/stdin','utf-8'));
+    console.log(d.layout_ok ? 'true' : 'false');
+  " 2>/dev/null || echo "true")
+
   # Recompute composite: pixelmatch 50% + nav 25% + judge 25%
+  # Veto: layout_ok=false caps score at 50 so broken states can't lock in
   score=$(node -e "
     const pm = ${desktop} || 0;
     const nav = ${nav_score} || 0;
     const judge = ${judge_score} || 50;
-    console.log(Math.round((pm * 0.50 + nav * 0.25 + judge * 0.25) * 100) / 100);
+    const layoutOk = '${layout_ok}' === 'true';
+    const raw = Math.round((pm * 0.50 + nav * 0.25 + judge * 0.25) * 100) / 100;
+    console.log(layoutOk ? raw : Math.min(raw, 50));
   " 2>/dev/null || echo "0")
 
   # Compare with best — strict improvement required

--- a/skills/migrate-header/templates/program-row.md.tmpl
+++ b/skills/migrate-header/templates/program-row.md.tmpl
@@ -1,0 +1,197 @@
+# Header Migration — Per-Row Polish Program
+
+## Goal
+
+Polish row {{ROW_INDEX}} of the migrated header to match the source with maximum visual fidelity.
+
+**Row description:** {{ROW_DESCRIPTION}}
+
+**Source row height: ~{{ROW_HEIGHT}}px at desktop.** Matching this height is critical for the visual score.
+
+## Your Environment
+
+- AEM Edge Delivery Services dev server running at http://localhost:{{PORT}}
+- Test page: http://localhost:{{PORT}}/
+- Nav loaded from: http://localhost:{{PORT}}/nav
+
+## What You CAN Modify
+
+You may ONLY modify **one file**:
+
+- `blocks/header/row-{{ROW_INDEX}}.css` — CSS for this row only
+
+## What You CANNOT Modify
+
+Everything else is off-limits. In particular:
+- `blocks/header/header.css` — base header styles (owned by the full-header pipeline)
+- `blocks/header/header.js` — header decoration logic
+- `nav.plain.html` — navigation content
+- `blocks/header/row-*.css` — other row files
+- `autoresearch/` — evaluation infrastructure (immutable)
+
+## How to Read History
+
+Before making changes, ALWAYS review what has been tried:
+1. `cat autoresearch/results/row-{{ROW_INDEX}}/results-row-{{ROW_INDEX}}.tsv` — Full experiment log (iteration, score, status, description)
+2. `git log --oneline` — Only successful improvements are in the git log
+3. `cat autoresearch/results/row-{{ROW_INDEX}}/latest-evaluation.json` — Last evaluation breakdown with scores and source/rendered heights
+4. **Read the diff image** — `autoresearch/results/row-{{ROW_INDEX}}/desktop-diff.png` shows pixel-level mismatches in red/yellow. Read this image to see WHERE the visual differences are.
+5. `git diff HEAD~1` (if available) — see what the last successful change actually did
+6. `cat autoresearch/results/row-{{ROW_INDEX}}/last-reverted.diff` (if exists) — see the exact diff of the last FAILED attempt
+
+If the TSV shows repeated reverts for similar approaches, DO NOT try that approach again.
+
+## Judge Feedback
+
+If `autoresearch/results/row-{{ROW_INDEX}}/judge-feedback.json` exists, read it FIRST.
+It contains a three-gate assessment from the previous iteration:
+
+```json
+{
+  "layout_ok": true,
+  "precision_ok": false,
+  "active_gate": 2,
+  "reasoning": "Layout correct. Font-family is Arial but source is Helvetica Neue. Row height 120px vs source 94px.",
+  "structure_issues": [],
+  "precision_issues": ["font-family: Arial vs source Helvetica Neue", "row height: 120px vs source 94px"],
+  "diagnosis": ["set font-family to Helvetica Neue and reduce row height to 94px"]
+}
+```
+
+The judge uses three gates — fix issues from the **active gate** only:
+
+- **Gate 1 (`layout_ok: false`)** — structural layout is wrong. Fix element
+  positions, row arrangement, element order. Do NOT work on fonts, sizes,
+  colors, or details.
+- **Gate 2 (`precision_ok: false`)** — layout is correct but fonts, sizes,
+  or dimensions don't match the source. Fix the specific CSS values listed
+  in `precision_issues`. Do NOT work on colors or decorative details.
+- **Gate 3 (both ok)** — structure and precision are correct. Fix colors,
+  spacing fine-tuning, decorative details.
+
+`reasoning` includes actual CSS values the judge measured (Gate 2) or
+visual observations (Gates 1 and 3). Prioritize fixing these items.
+
+## How the Evaluator Scores You
+
+After you exit, two evaluations run:
+
+1. **Pixelmatch evaluator** — compares your rendered row screenshot against the source pixel-by-pixel
+2. **LLM judge** — compares source, previous best, and your current render to assess semantic improvement
+
+The composite score (0-100) combines:
+- **50% weight**: Visual similarity via pixelmatch (desktop only)
+- **50% weight**: LLM judge (did this iteration improve? YES=100, NO=0)
+
+**Important**: The evaluator pads images to equal dimensions before comparing. If your rendered row is shorter than the source, the missing rows count as full-row pixel mismatches. **Matching the source row height (~{{ROW_HEIGHT}}px) is essential for a good visual score.**
+
+The outer loop keeps your changes if the score improves, reverts if it doesn't.
+
+## Source Reference
+
+- `autoresearch/source/desktop-row-{{ROW_INDEX}}.png` — Screenshot of source row at 1440px
+
+## Source Visual Tree (Row {{ROW_INDEX}} Subtree)
+
+Spatial hierarchy of row {{ROW_INDEX}} captured at 1440px viewport.
+Each line shows: `ID [role] [CxR grid] [bg:type] @x,y wxh "text..."`.
+Use this to understand the row's spatial structure — column counts and element positions.
+
+```
+{{ROW_VISUAL_TREE}}
+```
+
+## Row Section Style
+
+The section element wrapping this row has the following computed styles:
+
+```
+{{ROW_SECTION_STYLE}}
+```
+
+Use these as a baseline — your CSS should match or refine these values.
+
+## CSS Query Tool
+
+You have access to an on-demand CSS inspector that queries the source
+page's actual stylesheets via Chrome DevTools Protocol. Use it to get
+exact property values instead of guessing.
+
+### How to Use
+
+```bash
+# Open session on source URL (do this once at start of iteration)
+node "{{SKILL_HOME}}/scripts/css-query.js" open "{{URL}}" --session=row-{{ROW_INDEX}}-css-src
+
+# Query specific properties for an element
+node "{{SKILL_HOME}}/scripts/css-query.js" query "nav > a:first-child" font-size,color,font-weight --session=row-{{ROW_INDEX}}-css-src
+
+# Get all matched CSS rules for an element (full cascade)
+node "{{SKILL_HOME}}/scripts/css-query.js" cascade ".header-brand" --session=row-{{ROW_INDEX}}-css-src
+
+# List CSS custom properties defined in the source
+node "{{SKILL_HOME}}/scripts/css-query.js" vars --session=row-{{ROW_INDEX}}-css-src
+
+# Close when done (before committing)
+node "{{SKILL_HOME}}/scripts/css-query.js" close --session=row-{{ROW_INDEX}}-css-src
+```
+
+### When to Use
+
+- When the diff image shows a color mismatch: query `background-color` or `color`
+- When font rendering differs: query `font-family`, `font-size`, `font-weight`
+- When spacing is off: query `padding`, `margin`, `gap` values
+- When you need the source's CSS custom properties to map to EDS properties
+
+### Output
+
+```json
+{"font-size": {"value": "14px", "source": "author", "selector": ".nav-link", "file": "styles.css", "inherited": false}}
+```
+
+## Available Icons
+
+{{ICON_GUIDANCE}}
+
+## Constraints
+
+1. **CSS only.** You cannot touch `header.js` or `nav.plain.html`. If a DOM change is needed, the iteration cannot proceed — note it in the commit message and exit.
+2. **The header must render.** A broken header that doesn't display scores 0. Prefer incremental progress.
+3. **Commit before exiting.** Stage your change and commit: `git add blocks/header/row-{{ROW_INDEX}}.css && git commit -m "description"`
+4. **Read history first.** Check the TSV and diff image before changing anything.
+5. **One coherent goal per iteration.** You may change multiple related properties (e.g., height + padding + background) if they serve a single goal.
+
+## Strategy
+
+**At the start of every iteration**, open a CSS query session on the source URL:
+```bash
+node "{{SKILL_HOME}}/scripts/css-query.js" open "{{URL}}" --session=row-{{ROW_INDEX}}-css-src
+```
+Use it to get exact values before making changes. Close before committing.
+
+### Phase 1: Dimensions (score < 40)
+Match the source row height (~{{ROW_HEIGHT}}px). Query the source to get exact values:
+```bash
+node "{{SKILL_HOME}}/scripts/css-query.js" query "nav" height,padding-top,padding-bottom --session=row-{{ROW_INDEX}}-css-src
+```
+
+### Phase 2: Colors and layout (score 40-65)
+Query exact colors — don't guess from the screenshot:
+```bash
+node "{{SKILL_HOME}}/scripts/css-query.js" query "nav" background-color --session=row-{{ROW_INDEX}}-css-src
+node "{{SKILL_HOME}}/scripts/css-query.js" query "nav a" color --session=row-{{ROW_INDEX}}-css-src
+```
+Match horizontal layout: element alignment, spacing, gap values.
+
+### Phase 3: Visual polish (score > 65)
+Query specific properties for pixel-accurate matching:
+```bash
+node "{{SKILL_HOME}}/scripts/css-query.js" query "nav a" font-size,font-weight,letter-spacing,text-transform --session=row-{{ROW_INDEX}}-css-src
+```
+Use the diff image to identify remaining mismatch areas, then query those
+specific source elements to find the exact target values.
+
+### If stuck (3+ reverts in a row on similar approaches)
+- Use `css-query.js cascade` to see ALL CSS rules affecting the problem element
+- Look at the diff image to find the largest red areas
+- Query the exact source values for that area and compare against your CSS

--- a/skills/migrate-header/templates/program-row.md.tmpl
+++ b/skills/migrate-header/templates/program-row.md.tmpl
@@ -32,7 +32,7 @@ Everything else is off-limits. In particular:
 ## How to Read History
 
 Before making changes, ALWAYS review what has been tried:
-1. `cat autoresearch/results/row-{{ROW_INDEX}}/results-row-{{ROW_INDEX}}.tsv` — Full experiment log (iteration, score, status, description)
+1. `cat results-row-{{ROW_INDEX}}.tsv` — Full experiment log (iteration, score, status, description)
 2. `git log --oneline` — Only successful improvements are in the git log
 3. `cat autoresearch/results/row-{{ROW_INDEX}}/latest-evaluation.json` — Last evaluation breakdown with scores and source/rendered heights
 4. **Read the diff image** — `autoresearch/results/row-{{ROW_INDEX}}/desktop-diff.png` shows pixel-level mismatches in red/yellow. Read this image to see WHERE the visual differences are.
@@ -101,15 +101,10 @@ Use this to understand the row's spatial structure — column counts and element
 {{ROW_VISUAL_TREE}}
 ```
 
-## Row Section Style
+## Row Section Class
 
-The section element wrapping this row has the following computed styles:
-
-```
-{{ROW_SECTION_STYLE}}
-```
-
-Use these as a baseline — your CSS should match or refine these values.
+This row is wrapped in a section with class `{{ROW_SECTION_STYLE}}`. Target
+your CSS selectors at `.section.{{ROW_SECTION_STYLE}}` or its children.
 
 ## CSS Query Tool
 

--- a/skills/migrate-header/templates/program-row.md.tmpl
+++ b/skills/migrate-header/templates/program-row.md.tmpl
@@ -169,13 +169,18 @@ node "{{SKILL_HOME}}/scripts/css-query.js" open "{{URL}}" --session=row-{{ROW_IN
 ```
 Use it to get exact values before making changes. Close before committing.
 
-### Phase 1: Dimensions (score < 40)
+### Phase 1: Structure (score < 30)
+Get all elements rendering in the correct positions within the row.
+Elements should appear on the correct side (left/center/right) in the
+correct order.
+
+### Phase 2: Dimensions (score 30-50)
 Match the source row height (~{{ROW_HEIGHT}}px). Query the source to get exact values:
 ```bash
 node "{{SKILL_HOME}}/scripts/css-query.js" query "nav" height,padding-top,padding-bottom --session=row-{{ROW_INDEX}}-css-src
 ```
 
-### Phase 2: Colors and layout (score 40-65)
+### Phase 3: Colors and layout (score 50-70)
 Query exact colors — don't guess from the screenshot:
 ```bash
 node "{{SKILL_HOME}}/scripts/css-query.js" query "nav" background-color --session=row-{{ROW_INDEX}}-css-src
@@ -183,7 +188,7 @@ node "{{SKILL_HOME}}/scripts/css-query.js" query "nav a" color --session=row-{{R
 ```
 Match horizontal layout: element alignment, spacing, gap values.
 
-### Phase 3: Visual polish (score > 65)
+### Phase 4: Visual polish (score > 70)
 Query specific properties for pixel-accurate matching:
 ```bash
 node "{{SKILL_HOME}}/scripts/css-query.js" query "nav a" font-size,font-weight,letter-spacing,text-transform --session=row-{{ROW_INDEX}}-css-src
@@ -195,3 +200,7 @@ specific source elements to find the exact target values.
 - Use `css-query.js cascade` to see ALL CSS rules affecting the problem element
 - Look at the diff image to find the largest red areas
 - Query the exact source values for that area and compare against your CSS
+
+## NEVER STOP
+
+Continue working until you have made your changes and committed them. Then exit cleanly. The outer loop will evaluate and decide whether to keep your work. Do not second-guess the evaluator — just make your best change and commit.

--- a/tests/migrate-header/capture-visual-tree.test.js
+++ b/tests/migrate-header/capture-visual-tree.test.js
@@ -39,8 +39,9 @@ describe('parseArgs', () => {
 
 describe('buildConfig', () => {
   it('creates config with bundle in initScript', () => {
-    const config = buildConfig('/path/to/bundle.js', null);
+    const { config, stealthTmpFile } = buildConfig('/path/to/bundle.js', null);
     expect(config.browser.initScript).toEqual(['/path/to/bundle.js']);
+    expect(stealthTmpFile).toBeNull();
   });
 
   it('merges browser-recipe settings with bundle appended', () => {
@@ -56,16 +57,36 @@ describe('buildConfig', () => {
       },
     }));
 
-    const config = buildConfig('/path/to/bundle.js', recipePath);
+    const { config, stealthTmpFile } = buildConfig('/path/to/bundle.js', recipePath);
     expect(config.browser.initScript).toEqual(['stealth.js', '/path/to/bundle.js']);
     expect(config.browser.headless).toBe(false);
+    expect(stealthTmpFile).toBeNull();
 
     rmSync(tmpDir, { recursive: true });
   });
 
   it('handles missing browser-recipe file gracefully', () => {
-    const config = buildConfig('/path/to/bundle.js', '/nonexistent/recipe.json');
+    const { config } = buildConfig('/path/to/bundle.js', '/nonexistent/recipe.json');
     expect(config.browser.initScript).toEqual(['/path/to/bundle.js']);
+  });
+
+  it('writes stealthInitScript to temp file and prepends to initScript', () => {
+    const tmpDir = join(tmpdir(), `vt-test-stealth-${process.pid}`);
+    mkdirSync(tmpDir, { recursive: true });
+    const recipePath = join(tmpDir, 'recipe.json');
+    writeFileSync(recipePath, JSON.stringify({
+      cliConfig: { browser: {} },
+      stealthInitScript: 'console.log("stealth");',
+    }));
+
+    const { config, stealthTmpFile } = buildConfig('/path/to/bundle.js', recipePath);
+    expect(stealthTmpFile).toBeTruthy();
+    expect(readFileSync(stealthTmpFile, 'utf-8')).toBe('console.log("stealth");');
+    expect(config.browser.initScript[0]).toBe(stealthTmpFile);
+    expect(config.browser.initScript[1]).toBe('/path/to/bundle.js');
+
+    rmSync(tmpDir, { recursive: true });
+    try { rmSync(stealthTmpFile); } catch { /* noop */ }
   });
 });
 

--- a/tests/migrate-header/fixtures/row-0.json
+++ b/tests/migrate-header/fixtures/row-0.json
@@ -1,5 +1,6 @@
 {
   "index": 0,
+  "selector": "header > div:nth-child(1)",
   "description": "Top bar with logo and utility links",
   "bounds": { "y": 0, "height": 44 },
   "suggestedSectionStyle": "brand",

--- a/tests/migrate-header/fixtures/row-1.json
+++ b/tests/migrate-header/fixtures/row-1.json
@@ -1,5 +1,6 @@
 {
   "index": 1,
+  "selector": "header > div:nth-child(2)",
   "description": "Main navigation with 4 top-level links and submenus",
   "bounds": { "y": 44, "height": 50 },
   "suggestedSectionStyle": "main-nav",

--- a/tests/migrate-header/setup-polish-loop.test.js
+++ b/tests/migrate-header/setup-polish-loop.test.js
@@ -8,6 +8,8 @@ import {
   countNavItems,
   buildNavStructure,
   synthesizeStyles,
+  generateInitCss,
+  buildRowReplacements,
 } from '../../skills/migrate-header/scripts/setup-polish-loop.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -122,5 +124,100 @@ describe('synthesizeStyles', () => {
     expect(styles.cta['background-color'].value).toBe('rgb(0, 120, 212)');
     expect(styles.cta.color.value).toBe('rgb(255, 255, 255)');
     expect(styles.cta['border-radius'].value).toBe('4px');
+  });
+});
+
+describe('generateInitCss', () => {
+  it('generates @import rules for each row', () => {
+    const rows = loadFixtures();
+    const css = generateInitCss(rows);
+    expect(css).toContain("@import url('row-0.css');");
+    expect(css).toContain("@import url('row-1.css');");
+  });
+
+  it('preserves row order', () => {
+    const rows = loadFixtures();
+    const css = generateInitCss(rows);
+    const idx0 = css.indexOf('row-0.css');
+    const idx1 = css.indexOf('row-1.css');
+    expect(idx0).toBeLessThan(idx1);
+  });
+
+  it('ends with a trailing newline', () => {
+    const rows = loadFixtures();
+    const css = generateInitCss(rows);
+    expect(css.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('buildRowReplacements', () => {
+  it('returns row-specific template values', () => {
+    const rows = loadFixtures();
+    const r = buildRowReplacements(rows[0], {
+      port: '3000',
+      maxIterations: '30',
+      url: 'https://example.com',
+      skillHome: '/path/to/skill',
+    });
+    expect(r['{{ROW_INDEX}}']).toBe('0');
+    expect(r['{{ROW_SELECTOR}}']).toBe('header > div:nth-child(1)');
+    expect(r['{{ROW_SESSION}}']).toBe('row-0-eval');
+    expect(r['{{ROW_HEIGHT}}']).toBe('44');
+    expect(r['{{ROW_SECTION_STYLE}}']).toBe('brand');
+  });
+
+  it('provides fallback selector when none specified', () => {
+    const rows = loadFixtures();
+    const row = { ...rows[0], selector: undefined };
+    const r = buildRowReplacements(row, {
+      port: '3000',
+      maxIterations: '30',
+      url: 'https://example.com',
+      skillHome: '/path/to/skill',
+    });
+    expect(r['{{ROW_SELECTOR}}']).toBe('header > :nth-child(1)');
+  });
+
+  it('uses row description from data', () => {
+    const rows = loadFixtures();
+    const r = buildRowReplacements(rows[1], {
+      port: '3000',
+      maxIterations: '30',
+      url: 'https://example.com',
+      skillHome: '/path/to/skill',
+    });
+    expect(r['{{ROW_DESCRIPTION}}']).toBe(
+      'Main navigation with 4 top-level links and submenus',
+    );
+    expect(r['{{ROW_INDEX}}']).toBe('1');
+    expect(r['{{ROW_HEIGHT}}']).toBe('50');
+  });
+
+  it('provides fallback description when none specified', () => {
+    const rows = loadFixtures();
+    const row = { ...rows[0], description: undefined };
+    const r = buildRowReplacements(row, {
+      port: '3000',
+      maxIterations: '30',
+      url: 'https://example.com',
+      skillHome: '/path/to/skill',
+    });
+    expect(r['{{ROW_DESCRIPTION}}']).toBe('Row 0');
+  });
+
+  it('passes through opts to template keys', () => {
+    const rows = loadFixtures();
+    const r = buildRowReplacements(rows[0], {
+      port: '4000',
+      maxIterations: '50',
+      url: 'https://test.com',
+      skillHome: '/skill',
+      iconGuidance: 'Use :search: icon',
+    });
+    expect(r['{{PORT}}']).toBe('4000');
+    expect(r['{{MAX_ITERATIONS}}']).toBe('50');
+    expect(r['{{URL}}']).toBe('https://test.com');
+    expect(r['{{SKILL_HOME}}']).toBe('/skill');
+    expect(r['{{ICON_GUIDANCE}}']).toBe('Use :search: icon');
   });
 });

--- a/tests/migrate-header/setup-polish-loop.test.js
+++ b/tests/migrate-header/setup-polish-loop.test.js
@@ -175,7 +175,7 @@ describe('buildRowReplacements', () => {
       url: 'https://example.com',
       skillHome: '/path/to/skill',
     });
-    expect(r['{{ROW_SELECTOR}}']).toBe('header > :nth-child(1)');
+    expect(r['{{ROW_SELECTOR}}']).toBe('header .header > :nth-child(1)');
   });
 
   it('uses row description from data', () => {


### PR DESCRIPTION
## Summary

- Spawn one visual polish loop per header row in parallel, then run adaptive reconciliation on the full header
- Fix multiple bugs found during live testing on astrazeneca.com
- Fix pre-existing issues in capture-visual-tree.js (stealth propagation, initScript string spread)
- Add deterministic nav content extraction script to prevent LLM truncation of large dropdown menus
- Add layout_ok veto to prevent broken states from locking in as unbeatable baselines
- Document and fix playwright-cli usage (screenshot refs, run-code --filename sandbox, Context7 rule)

## Changes

### Per-row polish loops (core feature)
- Three new templates: `evaluate-row.js.tmpl`, `loop-row.sh.tmpl`, `program-row.md.tmpl`
- `setup-polish-loop.js` gains `--init-css` and `--row=N` modes
- SKILL.md Phase 5 rewritten: 5.1 setup, 5.2 parallel row dispatch, 5.3 adaptive reconciliation
- Each row owns its own `row-N.css`, composed via `@import` in `header.css`
- File-scoped git ratchet (backup-restore, no `reset --hard`) for parallel safety

### Bug fixes from live testing
- playwright-cli `screenshot` only accepts refs, not CSS selectors — use `locator.screenshot()` via `run-code`
- Row selector fallback: `header .header >` (EDS wraps sections in `div.header`)
- pngjs v7 renamed `lib/pngjs.js` to `lib/png.js` — use `createRequire` instead of hardcoded path
- `layout_ok=false` veto caps composite score at 50 (both loop templates + judge-first template)
- Deterministic nav content extraction via `extract-row-content.js` (prevents LLM innerHTML truncation)
- `run-code --filename=` sandbox: write temp scripts to `.playwright-cli/` not `/tmp/`

### Pre-existing fixes
- `capture-visual-tree.js`: propagate `stealthInitScript` from browser recipe (was silently dropped)
- `capture-visual-tree.js`: normalize `initScript` to array before spreading (string was char-spread)
- `.claude/rules/playwright-cli.md`: document screenshot refs, `run-code --filename`, sandbox, Context7 rule

## Test plan

- [x] 49 unit tests passing (setup-polish-loop + capture-visual-tree)
- [ ] Live test: run `/migrate-header` on a 2-row header site — verify parallel row loops dispatch and converge
- [ ] Live test: run on astrazeneca.com — verify nav content extraction captures all mega menu links
- [ ] Verify reconciliation triggers when score < 85% and skips when >= 85%

🤖 Generated with [Claude Code](https://claude.com/claude-code)